### PR TITLE
[Bug fix] Remove the pragma line leading to error with gcc 4.8

### DIFF
--- a/src/details.hpp
+++ b/src/details.hpp
@@ -20,7 +20,6 @@
 #include <boost/python.hpp>
 #include <Eigen/Core>
 
-#pragma GCC diagnostic error "-pedantic" // Alas only work for g++ 4.8
 #include <numpy/arrayobject.h>
 #include <iostream>
 


### PR DESCRIPTION
Fix bug concerning the pragma pedantic. Should compile with gcc 4.8.