### PR TITLE
Enable alignment between Eigen matrix and Numpy matrix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ release/
 _build/
 _release/
 *~
+Xcode/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,15 @@ IF(APPLE)
 ENDIF(APPLE)
 
 # ----------------------------------------------------
+# --- OPTIONS  ---------------------------------------
+# ----------------------------------------------------
+OPTION (EIGEN_NUMPY_ALIGNED "Directly aligned data between Numpy and Eigen" OFF)
+
+IF(EIGEN_NUMPY_ALIGNED)
+  ADD_DEFINITIONS(-DEIGENPY_ALIGNED)
+ENDIF(EIGEN_NUMPY_ALIGNED)
+
+# ----------------------------------------------------
 # --- DEPENDANCIES -----------------------------------
 # ----------------------------------------------------
 ADD_REQUIRED_DEPENDENCY("eigen3 >= 3.0.5")
@@ -102,6 +111,9 @@ ADD_LIBRARY(geometry SHARED unittest/geometry.cpp)
 TARGET_LINK_LIBRARIES(geometry ${Boost_LIBRARIES} ${PROJECT_NAME})
 SET_TARGET_PROPERTIES(geometry PROPERTIES PREFIX "")
 
+IF(EIGEN_NUMPY_ALIGNED)
+  PKG_CONFIG_APPEND_CFLAGS("-DEIGENPY_ALIGNED")
+ENDIF(EIGEN_NUMPY_ALIGNED)
 PKG_CONFIG_APPEND_CFLAGS("-I${PYTHON_INCLUDE_DIRS}")
 PKG_CONFIG_APPEND_CFLAGS("-I${NUMPY_INCLUDE_DIRS}")
 PKG_CONFIG_APPEND_LIBS("boost_python")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,17 @@
 #
-#  Copyright 2014 CNRS
+# Copyright (c) 2015 LAAS-CNRS
+#
+# This file is part of eigenpy.
+# eigenpy is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+# eigenpy is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.  You should
+# have received a copy of the GNU Lesser General Public License along
+# with eigenpy.  If not, see <http://www.gnu.org/licenses/>.
 #
 
 CMAKE_MINIMUM_REQUIRED(VERSION 2.6)

--- a/src/details.cpp
+++ b/src/details.cpp
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2015 LAAS-CNRS
+ *
+ * This file is part of eigenpy.
+ * eigenpy is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ * eigenpy is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.  You should
+ * have received a copy of the GNU Lesser General Public License along
+ * with eigenpy.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "eigenpy/details.hpp"
 
 namespace eigenpy

--- a/src/details.hpp
+++ b/src/details.hpp
@@ -108,7 +108,7 @@ namespace eigenpy
   {
     static MatType & construct(void*storage,int /*r*/,int c)
     {
-      return * new(storage) MatType(c);
+      return * new(storage) MatType(R,c);
     }
   };
 
@@ -117,7 +117,7 @@ namespace eigenpy
   {
     static MatType & construct(void*storage,int r,int /*c*/)
     {
-      return * new(storage) MatType(r);
+      return * new(storage) MatType(r,C);
     }
   };
 

--- a/src/details.hpp
+++ b/src/details.hpp
@@ -168,7 +168,6 @@ namespace eigenpy
     static void construct(PyObject* pyObj,
 			  bp::converter::rvalue_from_python_stage1_data* memory)
     {
-      typedef typename MatType::Scalar T;
       using namespace Eigen;
 
       PyArrayObject * pyArray = reinterpret_cast<PyArrayObject*>(pyObj);

--- a/src/details.hpp
+++ b/src/details.hpp
@@ -190,20 +190,26 @@ namespace eigenpy
   void enableEigenPySpecific()
   {
     import_array();
-
- #ifdef EIGEN_DONT_VECTORIZE
+    
+#ifdef EIGEN_DONT_VECTORIZE
+    
     boost::python::to_python_converter<MatType,
-				       eigenpy::EigenToPy<MatType,MatType> >();
+                                      eigenpy::EigenToPy<MatType,MatType> >();
     eigenpy::EigenFromPy<MatType,MatType>();
- #else 
-    typedef typename eigenpy::UnalignedEquivalent<MatType>::type MatTypeDontAlign;
+#else
     
     boost::python::to_python_converter<MatType,
 				       eigenpy::EigenToPy<MatType,MatType> >();
+    eigenpy::EigenFromPy<MatType,MatType>();
+    
+    typedef typename eigenpy::UnalignedEquivalent<MatType>::type MatTypeDontAlign;
+#ifndef EIGENPY_ALIGNED
     boost::python::to_python_converter<MatTypeDontAlign,
 				       eigenpy::EigenToPy<MatTypeDontAlign,MatTypeDontAlign> >();
     eigenpy::EigenFromPy<MatTypeDontAlign,MatTypeDontAlign>();
 #endif
+#endif
+
 
   }
 

--- a/src/eigenpy.cpp
+++ b/src/eigenpy.cpp
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2015 LAAS-CNRS
+ *
+ * This file is part of eigenpy.
+ * eigenpy is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ * eigenpy is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.  You should
+ * have received a copy of the GNU Lesser General Public License along
+ * with eigenpy.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include "eigenpy/eigenpy.hpp"
 
 namespace eigenpy

--- a/src/exception.cpp
+++ b/src/exception.cpp
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2015 LAAS-CNRS
+ *
+ * This file is part of eigenpy.
+ * eigenpy is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ * eigenpy is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.  You should
+ * have received a copy of the GNU Lesser General Public License along
+ * with eigenpy.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include <eigenpy/exception.hpp>
 
 

--- a/src/fwd.hpp
+++ b/src/fwd.hpp
@@ -27,11 +27,15 @@ namespace eigenpy
   {
     typedef Eigen::MatrixBase<D> MatType;
     typedef Eigen::Matrix<typename D::Scalar,
-			  D::RowsAtCompileTime,
-			  D::ColsAtCompileTime,
-			  D::Options | Eigen::DontAlign,
-			  D::MaxRowsAtCompileTime,
-			  D::MaxColsAtCompileTime>      type;
+             D::RowsAtCompileTime,
+             D::ColsAtCompileTime,
+#ifndef EIGENPY_ALIGNED
+             D::Options | Eigen::DontAlign,
+#else
+             D::Options,
+#endif
+             D::MaxRowsAtCompileTime,
+             D::MaxColsAtCompileTime> type;
   };
 
 } // namespace eigenpy

--- a/src/quaternion.hpp
+++ b/src/quaternion.hpp
@@ -39,7 +39,11 @@ namespace eigenpy
   template<>
   struct UnalignedEquivalent<Eigen::Quaterniond>
   {
-    typedef Eigen::Quaternion<double,Eigen::DontAlign> type;
+#ifndef EIGENPY_ALIGNED
+    typedef Eigen::Quaternion<Eigen::Quaterniond::Scalar,Eigen::DontAlign> type;
+#else
+    typedef Eigen::Quaterniond type;
+#endif
   };
 
   namespace bp = boost::python;
@@ -51,10 +55,15 @@ namespace eigenpy
     typedef Eigen::QuaternionBase<Quaternion> QuaternionBase;
     typedef typename eigenpy::UnalignedEquivalent<Quaternion>::type QuaternionUnaligned;
 
-    typedef typename QuaternionUnaligned::Scalar Scalar;
-    typedef Eigen::Matrix<Scalar,3,1,Eigen::DontAlign> Vector3;
+    typedef typename QuaternionBase::Scalar Scalar;
     typedef typename QuaternionUnaligned::Coefficients Coefficients;
+#ifndef EIGENPY_ALIGNED
+    typedef Eigen::Matrix<Scalar,3,1,Eigen::DontAlign> Vector3;
     typedef Eigen::Matrix<Scalar,3,3,Eigen::DontAlign> Matrix3;
+#else
+    typedef Eigen::Matrix<Scalar,3,1,0> Vector3;
+    typedef Eigen::Matrix<Scalar,3,3,0> Matrix3;
+#endif
 
     typedef Eigen::AngleAxis<Scalar> AngleAxisUnaligned;
 
@@ -169,8 +178,10 @@ namespace eigenpy
 				      bp::init<>())
 	.def(QuaternionVisitor<Quaternion>())
 	;
-    
+   
+#ifndef EIGENPY_ALIGNED
       bp::to_python_converter< Quaternion,QuaternionVisitor<Quaternion> >();
+#endif
     }
 
   };

--- a/unittest/geometry.cpp
+++ b/unittest/geometry.cpp
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2015 LAAS-CNRS
+ *
+ * This file is part of eigenpy.
+ * eigenpy is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ * eigenpy is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.  You should
+ * have received a copy of the GNU Lesser General Public License along
+ * with eigenpy.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #include "eigenpy/eigenpy.hpp"
 #include "eigenpy/geometry.hpp"


### PR DESCRIPTION
This PR aims at enabling the alignment between eigen and numpy objects (EIGEN_NUMPY_ALIGNED must be set to ON in Cmake).