### PR TITLE
Add Scalar template argument to UnalignedEquivalent struct.

### DIFF
--- a/src/fwd.hpp
+++ b/src/fwd.hpp
@@ -22,11 +22,11 @@
 
 namespace eigenpy
 {
-  template<typename D>
+  template<typename D, typename Scalar = typename D::Scalar>
   struct UnalignedEquivalent
   {
     typedef Eigen::MatrixBase<D> MatType;
-    typedef Eigen::Matrix<typename D::Scalar,
+    typedef Eigen::Matrix<Scalar,
              D::RowsAtCompileTime,
              D::ColsAtCompileTime,
 #ifndef EIGENPY_ALIGNED


### PR DESCRIPTION
* It allows creating unaligned equivalent of Eigen matrix using a
  different scalar type. This can be useful when matrix types use
  single precision floats, whereas Numpy matrix types use double
  precision floats by default.
* Default template argument value is Matrix D scalar type to preserve
  backward-compatibility.