### PR TITLE
Makes eigenpy compliant with NUMPY 1.8 (on Ubuntu 14.04 LTS)

### DIFF
--- a/src/details.hpp
+++ b/src/details.hpp
@@ -137,11 +137,12 @@ namespace eigenpy
     EigenFromPy()
     {
       bp::converter::registry::push_back
-	(&convertible,&construct,bp::type_id<MatType>());
+	(reinterpret_cast<void *(*)(_object *)>(&convertible),
+	 &construct,bp::type_id<MatType>());
     }
  
     // Determine if obj_ptr can be converted in a Eigenvec
-    static void* convertible(PyObject* obj_ptr)
+    static void* convertible(PyArrayObject* obj_ptr)
     {
       typedef typename MatType::Scalar T;
 
@@ -162,15 +163,18 @@ namespace eigenpy
 	    return 0;
 	  }
 
-      if ((PyArray_ObjectType(obj_ptr, 0)) != NumpyEquivalentType<T>::type_code)
+      if ((PyArray_ObjectType(reinterpret_cast<PyObject *>(obj_ptr), 0)) != NumpyEquivalentType<T>::type_code)
 	{
 #ifndef NDEBUG
 	  std::cerr << "The internal type as no Eigen equivalent." << std::endl;
 #endif
 	  return 0;
 	}
-
+#ifdef NPY_1_8_API_VERSION
+      if (!(PyArray_FLAGS(obj_ptr)))
+#else
       if (!(PyArray_FLAGS(obj_ptr) & NPY_ALIGNED))
+#endif
 	{
 #ifndef NDEBUG
 	  std::cerr << "NPY non-aligned matrices are not implemented." << std::endl;

--- a/src/details.hpp
+++ b/src/details.hpp
@@ -20,6 +20,11 @@
 #include <boost/python.hpp>
 #include <Eigen/Core>
 
+#include <numpy/numpyconfig.h>
+#ifdef NPY_1_8_API_VERSION
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#endif
+
 #include <numpy/arrayobject.h>
 #include <iostream>
 

--- a/src/fwd.hpp
+++ b/src/fwd.hpp
@@ -19,7 +19,10 @@
 
 #include <boost/python.hpp>
 #include <Eigen/Core>
+
+#ifdef NPY_1_8_API_VERSION
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#endif
 
 namespace eigenpy
 {

--- a/src/fwd.hpp
+++ b/src/fwd.hpp
@@ -19,6 +19,7 @@
 
 #include <boost/python.hpp>
 #include <Eigen/Core>
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 
 namespace eigenpy
 {

--- a/src/map.hpp
+++ b/src/map.hpp
@@ -60,9 +60,9 @@ namespace eigenpy
 
       const int R = (int)PyArray_DIMS(pyArray)[0];
       const int C = (int)PyArray_DIMS(pyArray)[1];
-      const int itemsize = PyArray_ITEMSIZE(pyArray);
-      const int stride1 = (int)PyArray_STRIDE(pyArray, 0) / itemsize;
-      const int stride2 = (int)PyArray_STRIDE(pyArray, 1) / itemsize;
+      const long int itemsize = PyArray_ITEMSIZE(pyArray);
+      const int stride1 = (int)PyArray_STRIDE(pyArray, 0) / (int)itemsize;
+      const int stride2 = (int)PyArray_STRIDE(pyArray, 1) / (int)itemsize;
       
       if( (MatType::RowsAtCompileTime!=R)
 	  && (MatType::RowsAtCompileTime!=Eigen::Dynamic) )
@@ -94,8 +94,8 @@ namespace eigenpy
       assert( (PyArray_DIMS(pyArray)[rowMajor]< INT_MAX)
 	      && (PyArray_STRIDE(pyArray, rowMajor) ));
       const int R = (int)PyArray_DIMS(pyArray)[rowMajor];
-      const int itemsize = PyArray_ITEMSIZE(pyArray);
-      const int stride = (int) PyArray_STRIDE(pyArray, rowMajor) / itemsize;;
+      const long int itemsize = PyArray_ITEMSIZE(pyArray);
+      const int stride = (int) PyArray_STRIDE(pyArray, rowMajor) / (int) itemsize;;
 
       if( (MatType::MaxSizeAtCompileTime!=R)
 	      && (MatType::MaxSizeAtCompileTime!=Eigen::Dynamic) )


### PR DESCRIPTION
This should remove the deprecated messages spanning all over the packages relying on pinocchio and thus on eigenpy.
