### PR TITLE
Add note for compiling eigenpy with python3 on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,23 @@ directory:
 Please note that CMake produces a `CMakeCache.txt` file which should
 be deleted to reconfigure a package from scratch.
 
+#### Compiling for python3 on macOS
+
+Make sure you have boost for python3 installed. If you use homebrew, you can install it via `brew install boost-python3`.
+
+Assuming you have python2 and python3 installed on your system, you can compile for python3 using
+
+```
+cmake -DPYTHON_EXECUTABLE=`which python3`  ..
+```
+
+In case you get an error as only the libraries for python2 are found, make sure macOS can find the python3 libraries. One way to ensure this is by adding a symbolic link to the python3 libraries like
+
+```
+ln -s /usr/local/Cellar/python/3.7.0/Frameworks/Python.framework/Versions/3.7/lib/libpython3.7.dylib /usr/loca/lib/libpython3.7.dylib
+```
+
+where the abolve file source path was determined by looking at the output of `brew ls --verbose python3 | grep libpython3`.
 
 ### Dependencies
 


### PR DESCRIPTION
Getting eigenpy (and pinocchio) to compile on macOS with python3 took me some effort. The required trick turned out to "only" add `-DPYTHON_EXECUTABLE=\`which python3\`` to the cmake argument.

Do you think this is worth adding to the README.md/installation instructions? I am happy to provide something similar for pinocchio as well.