### PR TITLE
Update package.xml to fix unstable build warnings

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>eigenpy</name>
-  <version>1.5.3</version>
+  <version>1.6.2</version>
   <description>Bindings between Numpy and Eigen using Boost.Python</description>
   <maintainer email="justin.carpentier@inria.fr">Justin Carpentier</maintainer>
   <maintainer email="wolfgang.merkt@ed.ac.uk">Wolfgang Merkt</maintainer>
@@ -11,6 +11,8 @@
 
   <url type="website">https://github.com/stack-of-tasks/eigenpy</url>
 
+  <build_depend>git</build_depend>
+  <build_depend>doxygen</build_depend>
   <depend>python</depend>
   <depend>python-numpy</depend>
   <depend>eigen</depend>


### PR DESCRIPTION
This PR fixes the unstable build warnings we are getting via email every time a PR is merged to master. It also updates the version number to the yet-to-be-released 1.6.2 which I suggest to tag and release once this PR is merged.

After this PR, I will make a new ROS buildfarm release which also changes from the previous catkinized version to regular third-party library. As part of this, I will update MoveIt to comply with the pkg-config search (as I believe #98 may take longer).