### PR TITLE
eigenpyConfig.cmake: find absolute library paths for all required libs

### DIFF
--- a/eigenpyConfig.cmake
+++ b/eigenpyConfig.cmake
@@ -2,5 +2,13 @@ cmake_minimum_required(VERSION 2.8.3)
 
 message(STATUS "Loading eigenpy from PkgConfig")
 
-find_package(PkgConfig)
+find_package(PkgConfig REQUIRED)
 pkg_check_modules(eigenpy REQUIRED eigenpy)
+
+# find absolute library paths for all eigenpy_LIBRARIES
+set(libs ${eigenpy_LIBRARIES})
+set(eigenpy_LIBRARIES "")
+foreach(lib ${libs})
+  find_library(abs_lib_${lib} ${lib} HINTS ${eigenpy_LIBRARY_DIRS})
+  list(APPEND eigenpy_LIBRARIES "${abs_lib_${lib}}")
+endforeach()


### PR DESCRIPTION
As cmake expects absolute library paths, while pkgconfig provides lib names only (together with
LIBRARY_DIRS), one needs to transform names to full library paths.

This fixes 7854c0f / #101. Without this fix, the MoveIt catkin build still fails with:
```
Errors     << moveit_ros_planning_interface:make /vol/sandbox/ros/logs/moveit_ros_planning_interface/build.make.000.log
/usr/bin/ld: cannot find -leigenpy
collect2: error: ld returned 1 exit status
```