### PR TITLE
core: patch Win32

### DIFF
--- a/include/eigenpy/numpy-allocator.hpp
+++ b/include/eigenpy/numpy-allocator.hpp
@@ -41,9 +41,9 @@ namespace eigenpy
       enum { NPY_ARRAY_MEMORY_CONTIGUOUS = SimilarMatrixType::IsRowMajor ? NPY_ARRAY_CARRAY : NPY_ARRAY_FARRAY };
       
       PyArrayObject * pyArray = (PyArrayObject*) call_PyArray_New(nd, shape,
-                                                             NumpyEquivalentType<Scalar>::type_code,
-                                                             mat.data(),
-                                                             NPY_ARRAY_MEMORY_CONTIGUOUS | NPY_ARRAY_ALIGNED);
+                                                                  NumpyEquivalentType<Scalar>::type_code,
+                                                                  mat.data(),
+                                                                  NPY_ARRAY_MEMORY_CONTIGUOUS | NPY_ARRAY_ALIGNED);
       
       return pyArray;
     }
@@ -69,9 +69,9 @@ namespace eigenpy
       enum { NPY_ARRAY_MEMORY_CONTIGUOUS_RO = SimilarMatrixType::IsRowMajor ? NPY_ARRAY_CARRAY_RO : NPY_ARRAY_FARRAY_RO };
       
       PyArrayObject * pyArray = (PyArrayObject*) call_PyArray_New(nd, shape,
-                                                             NumpyEquivalentType<Scalar>::type_code,
-                                                             const_cast<SimilarMatrixType &>(mat.derived()).data(),
-                                                             NPY_ARRAY_MEMORY_CONTIGUOUS_RO | NPY_ARRAY_ALIGNED);
+                                                                  NumpyEquivalentType<Scalar>::type_code,
+                                                                  const_cast<SimilarMatrixType &>(mat.derived()).data(),
+                                                                  NPY_ARRAY_MEMORY_CONTIGUOUS_RO | NPY_ARRAY_ALIGNED);
       
       return pyArray;
     }

--- a/include/eigenpy/numpy-allocator.hpp
+++ b/include/eigenpy/numpy-allocator.hpp
@@ -20,8 +20,8 @@ namespace eigenpy
     {
       typedef typename SimilarMatrixType::Scalar Scalar;
       
-      PyArrayObject * pyArray = (PyArrayObject*) PyArray_SimpleNew(nd, shape,
-                                                                   NumpyEquivalentType<Scalar>::type_code);
+      PyArrayObject * pyArray = (PyArrayObject*) call_PyArray_SimpleNew(nd, shape,
+                                                                        NumpyEquivalentType<Scalar>::type_code);
       
       // Copy data
       EigenAllocator<SimilarMatrixType>::copy(mat,pyArray);
@@ -40,11 +40,10 @@ namespace eigenpy
       typedef typename SimilarMatrixType::Scalar Scalar;
       enum { NPY_ARRAY_MEMORY_CONTIGUOUS = SimilarMatrixType::IsRowMajor ? NPY_ARRAY_CARRAY : NPY_ARRAY_FARRAY };
       
-      PyArrayObject * pyArray = (PyArrayObject*) PyArray_New(&PyArray_Type, nd, shape,
-                                                             NumpyEquivalentType<Scalar>::type_code, NULL,
-                                                             mat.data(), 0,
-                                                             NPY_ARRAY_MEMORY_CONTIGUOUS | NPY_ARRAY_ALIGNED,
-                                                             NULL);
+      PyArrayObject * pyArray = (PyArrayObject*) call_PyArray_New(nd, shape,
+                                                             NumpyEquivalentType<Scalar>::type_code,
+                                                             mat.data(),
+                                                             NPY_ARRAY_MEMORY_CONTIGUOUS | NPY_ARRAY_ALIGNED);
       
       return pyArray;
     }
@@ -69,11 +68,10 @@ namespace eigenpy
       typedef typename SimilarMatrixType::Scalar Scalar;
       enum { NPY_ARRAY_MEMORY_CONTIGUOUS_RO = SimilarMatrixType::IsRowMajor ? NPY_ARRAY_CARRAY_RO : NPY_ARRAY_FARRAY_RO };
       
-      PyArrayObject * pyArray = (PyArrayObject*) PyArray_New(&PyArray_Type, nd, shape,
-                                                             NumpyEquivalentType<Scalar>::type_code, NULL,
-                                                             const_cast<SimilarMatrixType &>(mat.derived()).data(), 0,
-                                                             NPY_ARRAY_MEMORY_CONTIGUOUS_RO | NPY_ARRAY_ALIGNED,
-                                                             NULL);
+      PyArrayObject * pyArray = (PyArrayObject*) call_PyArray_New(nd, shape,
+                                                             NumpyEquivalentType<Scalar>::type_code,
+                                                             const_cast<SimilarMatrixType &>(mat.derived()).data(),
+                                                             NPY_ARRAY_MEMORY_CONTIGUOUS_RO | NPY_ARRAY_ALIGNED);
       
       return pyArray;
     }

--- a/include/eigenpy/numpy.hpp
+++ b/include/eigenpy/numpy.hpp
@@ -35,9 +35,9 @@ namespace eigenpy
 #if defined _WIN32 || defined __CYGWIN__
 namespace eigenpy
 {
-  EIGENPY_DLLEXPORT PyObject*  call_PyArray_SimpleNew(int nd, npy_intp * shape, NPY_TYPES np_type);
+  EIGENPY_DLLEXPORT PyObject*  call_PyArray_SimpleNew(int nd, npy_intp * shape, int np_type);
 
-  EIGENPY_DLLEXPORT PyObject* call_PyArray_New(int nd, npy_intp * shape, NPY_TYPES np_type, void * data_ptr, int options);
+  EIGENPY_DLLEXPORT PyObject* call_PyArray_New(int nd, npy_intp * shape, int np_type, void * data_ptr, int options);
 
   EIGENPY_DLLEXPORT int call_PyArray_ObjectType(PyObject *, int);
 }

--- a/include/eigenpy/numpy.hpp
+++ b/include/eigenpy/numpy.hpp
@@ -19,11 +19,32 @@
 
 #include <numpy/noprefix.h>
 
-#define EIGENPY_GET_PY_ARRAY_TYPE(array) PyArray_ObjectType(reinterpret_cast<PyObject *>(array), 0)
+#if defined _WIN32 || defined __CYGWIN__
+  #define EIGENPY_GET_PY_ARRAY_TYPE(array) \
+    call_PyArray_ObjectType(reinterpret_cast<PyObject *>(array), 0)
+#else
+  #define EIGENPY_GET_PY_ARRAY_TYPE(array) \
+    PyArray_ObjectType(reinterpret_cast<PyObject *>(array), 0)
+#endif
 
 namespace eigenpy
 {
   void EIGENPY_DLLEXPORT import_numpy();
 }
+
+#if defined _WIN32 || defined __CYGWIN__
+namespace eigenpy
+{
+  EIGENPY_DLLEXPORT PyArrayObject*  call_PyArray_SimpleNew(npy_intp nd, npy_intp * shape, NPY_TYPES np_type);
+
+  EIGENPY_DLLEXPORT PyArrayObject* call_PyArray_New(npy_intp nd, npy_intp * shape, NPY_TYPES np_type, void * data_ptr, npy_intp options);
+
+  EIGENPY_DLLEXPORT int call_PyArray_ObjectType(PyObject *, int);
+}
+#else
+  #define call_PyArray_SimpleNew PyArray_SimpleNew
+  #define call_PyArray_New(nd,shape,np_type,data_ptr,options) \
+    PyArray_New(&PyArray_Type,nd,shape,np_type,NULL,data_ptr,0,options,NULL)
+#endif
 
 #endif // ifndef __eigenpy_numpy_hpp__

--- a/include/eigenpy/numpy.hpp
+++ b/include/eigenpy/numpy.hpp
@@ -35,9 +35,9 @@ namespace eigenpy
 #if defined _WIN32 || defined __CYGWIN__
 namespace eigenpy
 {
-  EIGENPY_DLLEXPORT PyArrayObject*  call_PyArray_SimpleNew(npy_intp nd, npy_intp * shape, NPY_TYPES np_type);
+  EIGENPY_DLLEXPORT PyObject*  call_PyArray_SimpleNew(int nd, npy_intp * shape, NPY_TYPES np_type);
 
-  EIGENPY_DLLEXPORT PyArrayObject* call_PyArray_New(npy_intp nd, npy_intp * shape, NPY_TYPES np_type, void * data_ptr, npy_intp options);
+  EIGENPY_DLLEXPORT PyObject* call_PyArray_New(int nd, npy_intp * shape, NPY_TYPES np_type, void * data_ptr, npy_intp options);
 
   EIGENPY_DLLEXPORT int call_PyArray_ObjectType(PyObject *, int);
 }

--- a/include/eigenpy/numpy.hpp
+++ b/include/eigenpy/numpy.hpp
@@ -37,7 +37,7 @@ namespace eigenpy
 {
   EIGENPY_DLLEXPORT PyObject*  call_PyArray_SimpleNew(int nd, npy_intp * shape, NPY_TYPES np_type);
 
-  EIGENPY_DLLEXPORT PyObject* call_PyArray_New(int nd, npy_intp * shape, NPY_TYPES np_type, void * data_ptr, npy_intp options);
+  EIGENPY_DLLEXPORT PyObject* call_PyArray_New(int nd, npy_intp * shape, NPY_TYPES np_type, void * data_ptr, int options);
 
   EIGENPY_DLLEXPORT int call_PyArray_ObjectType(PyObject *, int);
 }

--- a/src/numpy.cpp
+++ b/src/numpy.cpp
@@ -17,12 +17,12 @@ namespace eigenpy
 
 #if defined _WIN32 || defined __CYGWIN__
 
-  PyObject* call_PyArray_SimpleNew(int nd, npy_intp * shape, NPY_TYPES np_type)
+  PyObject* call_PyArray_SimpleNew(int nd, npy_intp * shape, int np_type)
   {
     return PyArray_SimpleNew(nd,shape,np_type);
   }
 
-  PyObject* call_PyArray_New(int nd, npy_intp * shape, NPY_TYPES np_type, void * data_ptr, int options)
+  PyObject* call_PyArray_New(int nd, npy_intp * shape, int np_type, void * data_ptr, int options)
   {
     return PyArray_New(&PyArray_Type,nd,shape,np_type,NULL,data_ptr,0,options,NULL);
   }

--- a/src/numpy.cpp
+++ b/src/numpy.cpp
@@ -14,4 +14,23 @@ namespace eigenpy
       PyErr_SetString(PyExc_ImportError, "numpy.core.multiarray failed to import");
     }
   }
+
+#if defined _WIN32 || defined __CYGWIN__
+
+  PyArrayObject* call_PyArray_SimpleNew(npy_intp nd, npy_intp * shape, NPY_TYPES np_type)
+  {
+    return PyArray_SimpleNew(nd,shape,np_type);
+  }
+
+  PyArrayObject* call_PyArray_New(npy_intp nd, npy_intp * shape, NPY_TYPES np_type, void * data_ptr, npy_intp options)
+  {
+    return PyArray_New(&PyArray_Type,nd,shape,np_type,NULL,data_ptr,0,options,NULL);
+  }
+  
+  int call_PyArray_ObjectType(PyObject * obj, int val)
+  {
+    return PyArray_ObjectType(obj,val);
+  }
+
+#endif
 }

--- a/src/numpy.cpp
+++ b/src/numpy.cpp
@@ -19,10 +19,10 @@ namespace eigenpy
 
   PyObject* call_PyArray_SimpleNew(int nd, npy_intp * shape, NPY_TYPES np_type)
   {
-    return (PyArrayObject*)PyArray_SimpleNew(nd,shape,np_type);
+    return PyArray_SimpleNew(nd,shape,np_type);
   }
 
-  PyObject* call_PyArray_New(int nd, npy_intp * shape, NPY_TYPES np_type, void * data_ptr, npy_intp options)
+  PyObject* call_PyArray_New(int nd, npy_intp * shape, NPY_TYPES np_type, void * data_ptr, int options)
   {
     return PyArray_New(&PyArray_Type,nd,shape,np_type,NULL,data_ptr,0,options,NULL);
   }

--- a/src/numpy.cpp
+++ b/src/numpy.cpp
@@ -17,12 +17,12 @@ namespace eigenpy
 
 #if defined _WIN32 || defined __CYGWIN__
 
-  PyArrayObject* call_PyArray_SimpleNew(npy_intp nd, npy_intp * shape, NPY_TYPES np_type)
+  PyObject* call_PyArray_SimpleNew(int nd, npy_intp * shape, NPY_TYPES np_type)
   {
-    return PyArray_SimpleNew(nd,shape,np_type);
+    return (PyArrayObject*)PyArray_SimpleNew(nd,shape,np_type);
   }
 
-  PyArrayObject* call_PyArray_New(npy_intp nd, npy_intp * shape, NPY_TYPES np_type, void * data_ptr, npy_intp options)
+  PyObject* call_PyArray_New(int nd, npy_intp * shape, NPY_TYPES np_type, void * data_ptr, npy_intp options)
   {
     return PyArray_New(&PyArray_Type,nd,shape,np_type,NULL,data_ptr,0,options,NULL);
   }


### PR DESCRIPTION
which is not able to retrieve EIGENPY_ARRAY_API when compiling other module because the symbol is not exported