### PR TITLE
Adding GitHub workflow as Windows CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,48 @@
+name: Build Eigenpy
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+          os: [windows-latest]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Checkout submodules
+      run: |
+        git submodule update --init
+    - uses: goanpeca/setup-miniconda@v1
+      with:
+        activate-environment: eigenpy
+        environment-file: ci/environment.yml
+        python-version: 3.7
+    - name: Build Eigenpy
+      shell: cmd /C CALL {0}
+      run: |
+        :: unset extra Boost envs
+        set Boost_ROOT=
+        set BOOST_ROOT_1_69_0=
+        set BOOST_ROOT_1_72_0=
+        set PATH=%PATH:C:\hostedtoolcache\windows\Boost\1.72.0;=%
+
+        :: start building
+        call "%programfiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" amd64
+        mkdir build
+        pushd build
+        set PKG_CONFIG_PATH=%CONDA_PREFIX%\Library\share\pkgconfig
+        cmake ^
+          -G "NMake Makefiles" ^
+          -DCMAKE_INSTALL_PREFIX=%CONDA_PREFIX%\Library ^
+          -DCMAKE_BUILD_TYPE=Release ^
+          -DEIGENPY_SITELIB_ROOT=%CONDA_PREFIX% ^
+          -DEIGEN3_FOUND=1 ^
+          -DEIGEN3_INCLUDE_DIRS=%CONDA_PREFIX%\Library\include\eigen3 ^
+          -DPYTHON_EXECUTABLE=%CONDA_PREFIX%\python.exe ^
+          ..
+        cmake --build . --config Release --target install

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -1,0 +1,10 @@
+name: eigenpy
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - eigen
+  - cmake
+  - numpy
+  - pkg-config
+  - boost


### PR DESCRIPTION
I am trying to synthesize the build process we used in [`eigenpy-feedstock`](https://github.com/conda-forge/eigenpy-feedstock), but do it in GitHub workflow.

Hope that can catch Windows build issues per check-in.