### PR TITLE
Remove silly warnings

### DIFF
--- a/include/eigenpy/numpy-allocator.hpp
+++ b/include/eigenpy/numpy-allocator.hpp
@@ -20,7 +20,7 @@ namespace eigenpy
     {
       typedef typename SimilarMatrixType::Scalar Scalar;
       
-      PyArrayObject * pyArray = (PyArrayObject*) call_PyArray_SimpleNew(nd, shape,
+      PyArrayObject * pyArray = (PyArrayObject*) call_PyArray_SimpleNew(static_cast<int>(nd), shape,
                                                                         NumpyEquivalentType<Scalar>::type_code);
       
       // Copy data
@@ -42,7 +42,7 @@ namespace eigenpy
       
       if(NumpyType::sharedMemory())
       {
-        PyArrayObject * pyArray = (PyArrayObject*) call_PyArray_New(nd, shape,
+        PyArrayObject * pyArray = (PyArrayObject*) call_PyArray_New(static_cast<int>(nd), shape,
                                                                     NumpyEquivalentType<Scalar>::type_code,
                                                                     mat.data(),
                                                                     NPY_ARRAY_MEMORY_CONTIGUOUS | NPY_ARRAY_ALIGNED);
@@ -77,7 +77,7 @@ namespace eigenpy
       
       if(NumpyType::sharedMemory())
       {
-        PyArrayObject * pyArray = (PyArrayObject*) call_PyArray_New(nd, shape,
+        PyArrayObject * pyArray = (PyArrayObject*) call_PyArray_New(static_cast<int>(nd), shape,
                                                                     NumpyEquivalentType<Scalar>::type_code,
                                                                     const_cast<SimilarMatrixType &>(mat.derived()).data(),
                                                                     NPY_ARRAY_MEMORY_CONTIGUOUS_RO | NPY_ARRAY_ALIGNED);


### PR DESCRIPTION
Remove a few conversion warnings.
Eigenpy doesn't issue any compilation warnings now.