### PR TITLE
Reduce compilation time by 75%, memory usage by 63%

### DIFF
--- a/include/eigenpy/eigenpy.hpp
+++ b/include/eigenpy/eigenpy.hpp
@@ -53,15 +53,6 @@ namespace eigenpy
    * using a native Eigen::MatrixBase, simply repeat the same arg twice. */
   template<typename MatType,typename EigenEquivalentType>
   EIGENPY_DEPRECATED void enableEigenPySpecific();
-
-  template<typename Scalar, int Options>
-  EIGEN_DONT_INLINE void exposeType();
-
-  template<typename Scalar>
-  EIGEN_DONT_INLINE void exposeType()
-  {
-    exposeType<Scalar,0>();
-  }
     
 } // namespace eigenpy
 

--- a/include/eigenpy/eigenpy.hpp
+++ b/include/eigenpy/eigenpy.hpp
@@ -55,32 +55,7 @@ namespace eigenpy
   EIGENPY_DEPRECATED void enableEigenPySpecific();
 
   template<typename Scalar, int Options>
-  EIGEN_DONT_INLINE void exposeType()
-  {
-    EIGENPY_MAKE_TYPEDEFS_ALL_SIZES(Scalar,Options,s);
-    
-    ENABLE_SPECIFIC_MATRIX_TYPE(Vector2s);
-    ENABLE_SPECIFIC_MATRIX_TYPE(RowVector2s);
-    ENABLE_SPECIFIC_MATRIX_TYPE(Matrix2s);
-    ENABLE_SPECIFIC_MATRIX_TYPE(Matrix2Xs);
-    ENABLE_SPECIFIC_MATRIX_TYPE(MatrixX2s);
-    
-    ENABLE_SPECIFIC_MATRIX_TYPE(Vector3s);
-    ENABLE_SPECIFIC_MATRIX_TYPE(RowVector3s);
-    ENABLE_SPECIFIC_MATRIX_TYPE(Matrix3s);
-    ENABLE_SPECIFIC_MATRIX_TYPE(Matrix3Xs);
-    ENABLE_SPECIFIC_MATRIX_TYPE(MatrixX3s);
-    
-    ENABLE_SPECIFIC_MATRIX_TYPE(Vector4s);
-    ENABLE_SPECIFIC_MATRIX_TYPE(RowVector4s);
-    ENABLE_SPECIFIC_MATRIX_TYPE(Matrix4s);
-    ENABLE_SPECIFIC_MATRIX_TYPE(Matrix4Xs);
-    ENABLE_SPECIFIC_MATRIX_TYPE(MatrixX4s);
-    
-    ENABLE_SPECIFIC_MATRIX_TYPE(VectorXs);
-    ENABLE_SPECIFIC_MATRIX_TYPE(RowVectorXs);
-    ENABLE_SPECIFIC_MATRIX_TYPE(MatrixXs);
-  }
+  EIGEN_DONT_INLINE void exposeType();
 
   template<typename Scalar>
   EIGEN_DONT_INLINE void exposeType()

--- a/src/eigenpy.cpp
+++ b/src/eigenpy.cpp
@@ -8,10 +8,37 @@
 
 namespace eigenpy
 {
-
   void seed(unsigned int seed_value)
   {
     srand(seed_value);
+  }
+
+  template<typename Scalar, int Options>
+  EIGEN_DONT_INLINE void exposeType()
+  {
+    EIGENPY_MAKE_TYPEDEFS_ALL_SIZES(Scalar,Options,s);
+
+    ENABLE_SPECIFIC_MATRIX_TYPE(Vector2s);
+    ENABLE_SPECIFIC_MATRIX_TYPE(RowVector2s);
+    ENABLE_SPECIFIC_MATRIX_TYPE(Matrix2s);
+    ENABLE_SPECIFIC_MATRIX_TYPE(Matrix2Xs);
+    ENABLE_SPECIFIC_MATRIX_TYPE(MatrixX2s);
+
+    ENABLE_SPECIFIC_MATRIX_TYPE(Vector3s);
+    ENABLE_SPECIFIC_MATRIX_TYPE(RowVector3s);
+    ENABLE_SPECIFIC_MATRIX_TYPE(Matrix3s);
+    ENABLE_SPECIFIC_MATRIX_TYPE(Matrix3Xs);
+    ENABLE_SPECIFIC_MATRIX_TYPE(MatrixX3s);
+
+    ENABLE_SPECIFIC_MATRIX_TYPE(Vector4s);
+    ENABLE_SPECIFIC_MATRIX_TYPE(RowVector4s);
+    ENABLE_SPECIFIC_MATRIX_TYPE(Matrix4s);
+    ENABLE_SPECIFIC_MATRIX_TYPE(Matrix4Xs);
+    ENABLE_SPECIFIC_MATRIX_TYPE(MatrixX4s);
+
+    ENABLE_SPECIFIC_MATRIX_TYPE(VectorXs);
+    ENABLE_SPECIFIC_MATRIX_TYPE(RowVectorXs);
+    ENABLE_SPECIFIC_MATRIX_TYPE(MatrixXs);
   }
 
   void exposeMatrixInt();


### PR DESCRIPTION
This PR reduces memory use during compilation (single core) from 3.06 GB to 1.12 GB (-63.4%) and compilation time from 5min56s to 1min34s (-75%).

**Background:** We've recently seen spikes across EigenPy, Pinocchio, and Crocoddyl which cause issues on CI as well as developer machines (Crocoddyl spiking up to 60 GB RAM). Iterations during development are really slow now. This addresses the issue for EigenPy.

**Note:** I am not 100% clear whether this has a performance penalty during runtime and there is no unit test to my knowledge checking for it? @jcarpent Do you know of other ways to reduce memory and compilation time?

All timings below are for Debug builds (`cmake ..`).

## Before

```
Command being timed: "make -j1"
User time (seconds): 335.07
System time (seconds): 20.50
Percent of CPU this job got: 99%
Elapsed (wall clock) time (h:mm:ss or m:ss): 5:56.26
Average shared text size (kbytes): 0
Average unshared data size (kbytes): 0
Average stack size (kbytes): 0
Average total size (kbytes): 0
Maximum resident set size (kbytes): 3064464
Average resident set size (kbytes): 0
Major (requiring I/O) page faults: 78
Minor (reclaiming a frame) page faults: 13195975
Voluntary context switches: 2676
Involuntary context switches: 3596
Swaps: 0
File system inputs: 59568
File system outputs: 3266600
Socket messages sent: 0
Socket messages received: 0
Signals delivered: 0
Page size (bytes): 4096
Exit status: 0
```

```
Test project /home/wxm/dev/install_ws/src/eigenpy/build
      Start  1: matrix
 1/17 Test  #1: matrix ...........................   Passed    0.10 sec
      Start  2: geometry
 2/17 Test  #2: geometry .........................   Passed    0.07 sec
      Start  3: complex
 3/17 Test  #3: complex ..........................   Passed    0.06 sec
      Start  4: return_by_ref
 4/17 Test  #4: return_by_ref ....................   Passed    0.07 sec
      Start  5: eigen_ref
 5/17 Test  #5: eigen_ref ........................   Passed    0.07 sec
      Start  6: py-matrix
 6/17 Test  #6: py-matrix ........................   Passed    0.07 sec
      Start  7: py-geometry
 7/17 Test  #7: py-geometry ......................   Passed    0.07 sec
      Start  8: py-complex
 8/17 Test  #8: py-complex .......................   Passed    0.07 sec
      Start  9: py-return-by-ref
 9/17 Test  #9: py-return-by-ref .................   Passed    0.07 sec
      Start 10: py-eigen-ref
10/17 Test #10: py-eigen-ref .....................   Passed    0.07 sec
      Start 11: py-switch
11/17 Test #11: py-switch ........................   Passed    0.07 sec
      Start 12: py-dimensions
12/17 Test #12: py-dimensions ....................   Passed    0.07 sec
      Start 13: py-version
13/17 Test #13: py-version .......................   Passed    0.07 sec
      Start 14: py-eigen-solver
14/17 Test #14: py-eigen-solver ..................   Passed    0.12 sec
      Start 15: py-self-adjoint-eigen-solver
15/17 Test #15: py-self-adjoint-eigen-solver .....   Passed    0.08 sec
      Start 16: py-LLT
16/17 Test #16: py-LLT ...........................   Passed    0.08 sec
      Start 17: py-LDLT
17/17 Test #17: py-LDLT ..........................   Passed    0.07 sec

100% tests passed, 0 tests failed out of 17

Total Test time (real) =   1.28 sec
```

## After

```
Command being timed: "make -j1"
User time (seconds): 84.06
System time (seconds): 10.02
Percent of CPU this job got: 99%
Elapsed (wall clock) time (h:mm:ss or m:ss): 1:34.49
Average shared text size (kbytes): 0
Average unshared data size (kbytes): 0
Average stack size (kbytes): 0
Average total size (kbytes): 0
Maximum resident set size (kbytes): 1122904
Average resident set size (kbytes): 0
Major (requiring I/O) page faults: 82
Minor (reclaiming a frame) page faults: 5982525
Voluntary context switches: 2562
Involuntary context switches: 2385
Swaps: 0
File system inputs: 54616
File system outputs: 589976
Socket messages sent: 0
Socket messages received: 0
Signals delivered: 0
Page size (bytes): 4096
Exit status: 0
```

```
Test project /home/wxm/dev/install_ws/src/eigenpy/build
      Start  1: matrix
 1/17 Test  #1: matrix ...........................   Passed    0.13 sec
      Start  2: geometry
 2/17 Test  #2: geometry .........................   Passed    0.07 sec
      Start  3: complex
 3/17 Test  #3: complex ..........................   Passed    0.07 sec
      Start  4: return_by_ref
 4/17 Test  #4: return_by_ref ....................   Passed    0.07 sec
      Start  5: eigen_ref
 5/17 Test  #5: eigen_ref ........................   Passed    0.07 sec
      Start  6: py-matrix
 6/17 Test  #6: py-matrix ........................   Passed    0.09 sec
      Start  7: py-geometry
 7/17 Test  #7: py-geometry ......................   Passed    0.07 sec
      Start  8: py-complex
 8/17 Test  #8: py-complex .......................   Passed    0.08 sec
      Start  9: py-return-by-ref
 9/17 Test  #9: py-return-by-ref .................   Passed    0.07 sec
      Start 10: py-eigen-ref
10/17 Test #10: py-eigen-ref .....................   Passed    0.07 sec
      Start 11: py-switch
11/17 Test #11: py-switch ........................   Passed    0.07 sec
      Start 12: py-dimensions
12/17 Test #12: py-dimensions ....................   Passed    0.07 sec
      Start 13: py-version
13/17 Test #13: py-version .......................   Passed    0.07 sec
      Start 14: py-eigen-solver
14/17 Test #14: py-eigen-solver ..................   Passed    0.12 sec
      Start 15: py-self-adjoint-eigen-solver
15/17 Test #15: py-self-adjoint-eigen-solver .....   Passed    0.08 sec
      Start 16: py-LLT
16/17 Test #16: py-LLT ...........................   Passed    0.10 sec
      Start 17: py-LDLT
17/17 Test #17: py-LDLT ..........................   Passed    0.07 sec

100% tests passed, 0 tests failed out of 17

Total Test time (real) =   1.39 sec
```