### PR TITLE
package.xml: Prepare for Ubuntu 20.04 / Python3

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>eigenpy</name>
   <version>2.3.1</version>
   <description>Bindings between Numpy and Eigen using Boost.Python</description>

--- a/package.xml
+++ b/package.xml
@@ -13,8 +13,10 @@
 
   <build_depend>git</build_depend>
   <build_depend>doxygen</build_depend>
-  <depend>python</depend>
-  <depend>python-numpy</depend>
+  <depend condition="$ROS_PYTHON_VERSION == 2">python</depend>
+  <depend condition="$ROS_PYTHON_VERSION == 3">python3</depend>
+  <depend condition="$ROS_PYTHON_VERSION == 2">python-numpy</depend>
+  <depend condition="$ROS_PYTHON_VERSION == 3">python3-numpy</depend>
   <depend>eigen</depend>
   <depend>boost</depend>
 


### PR DESCRIPTION
This adds compatibility with Ubuntu 20.04 and distributions that default to Python 3.

I've tested this with a CI based on 20.04.