### PR TITLE
package.xml: Add exec_depend on catkin or ament_cmake

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,7 @@
   <version>2.4.1</version>
   <description>Bindings between Numpy and Eigen using Boost.Python</description>
   <maintainer email="justin.carpentier@inria.fr">Justin Carpentier</maintainer>
-  <maintainer email="wolfgang.merkt@ed.ac.uk">Wolfgang Merkt</maintainer>
+  <maintainer email="wolfgang@robots.ox.ac.uk">Wolfgang Merkt</maintainer>
   <author>Justin Carpentier</author>
   <author>Nicolas Mansard</author>
   <license>BSD</license>
@@ -13,6 +13,9 @@
 
   <build_depend>git</build_depend>
   <build_depend>doxygen</build_depend>
+  <!-- The following tags are recommended by REP-136 -->
+  <exec_depend condition="$ROS_VERSION == 1">catkin</exec_depend>
+  <exec_depend condition="$ROS_VERSION == 2">ament_cmake</exec_depend>
   <depend condition="$ROS_PYTHON_VERSION == 2">python</depend>
   <depend condition="$ROS_PYTHON_VERSION == 3">python3</depend>
   <depend condition="$ROS_PYTHON_VERSION == 2">python-numpy</depend>


### PR DESCRIPTION
Required for packaging according to REP-136