### PR TITLE
fix unit-tests for numpy 1.20

### DIFF
--- a/include/eigenpy/numpy.hpp
+++ b/include/eigenpy/numpy.hpp
@@ -22,10 +22,10 @@
 
 #if defined _WIN32 || defined __CYGWIN__
   #define EIGENPY_GET_PY_ARRAY_TYPE(array) \
-    call_PyArray_ObjectType(reinterpret_cast<PyObject *>(array), 0)
+    call_PyArray_MinScalarType(array)->type_num
 #else
   #define EIGENPY_GET_PY_ARRAY_TYPE(array) \
-    PyArray_ObjectType(reinterpret_cast<PyObject *>(array), 0)
+    PyArray_MinScalarType(array)->type_num
 #endif
 
 namespace eigenpy
@@ -43,7 +43,7 @@ namespace eigenpy
 
   EIGENPY_DLLAPI PyObject* call_PyArray_New(PyTypeObject * py_type_ptr, int nd, npy_intp * shape, int np_type, void * data_ptr, int options);
 
-  EIGENPY_DLLAPI int call_PyArray_ObjectType(PyObject *, int);
+  EIGENPY_DLLAPI int call_PyArray_MinScalarType(PyObject *, int);
 
   EIGENPY_DLLAPI PyTypeObject * getPyArrayType();
 

--- a/include/eigenpy/user-type.hpp
+++ b/include/eigenpy/user-type.hpp
@@ -198,6 +198,8 @@ namespace eigenpy
                                          copyswap, copyswapn,
                                          dotfunc);
     
+    PyArray_RegisterCanCast(PyArray_DescrFromType(NPY_OBJECT), code, NPY_NOSCALAR);
+    
     return code;
   }
   

--- a/src/numpy.cpp
+++ b/src/numpy.cpp
@@ -37,9 +37,9 @@ namespace eigenpy
     return PyArray_New(py_type_ptr,nd,shape,np_type,NULL,data_ptr,0,options,NULL);
   }
   
-  int call_PyArray_ObjectType(PyObject * obj, int val)
+  int call_PyArray_MinScalarType(PyObject * obj, int val)
   {
-    return PyArray_ObjectType(obj,val);
+    return PyArray_MinScalarType(obj,val);
   }
 
   PyTypeObject * getPyArrayType() { return &PyArray_Type; }


### PR DESCRIPTION
Hi,

The `py-user-type`unit test  stopped working on Arch with numpy 1.20 (which requires python >= 3.7).

I didn't see anything related to safe casts or  `num_type` changes in the [changelog](https://github.com/numpy/numpy/releases/tag/v1.20.0), but switching from `numpy<1.20` to `numpy >=1.20` easily shows that the tests were working in 1.19.5 and are failing since 1.20.0.

This PR tries to address that. 
The first commit seems legit to me, but the second feels more like a hack. 
I think we shouldn't get that `dtype('O')` in the first place. I checked that `dotfunc` was called in 1.19.5, but isn't called anymore on 1.20.0, so maybe the issue is more at the registration step.