### PR TITLE
Export name types

### DIFF
--- a/include/eigenpy/angle-axis.hpp
+++ b/include/eigenpy/angle-axis.hpp
@@ -59,7 +59,7 @@ namespace eigenpy
            ((bp::arg("self"),bp::arg("angle"),bp::arg("axis")),
             "Initialize from angle and axis."))
       .def(bp::init<Matrix3>
-           ((bp::arg("self"),bp::arg("rotation matrix")),
+           ((bp::arg("self"),bp::arg("R")),
             "Initialize from a rotation matrix"))
       .def(bp::init<Quaternion>((bp::arg("self"),bp::arg("quaternion")),
                                 "Initialize from a quaternion."))
@@ -84,9 +84,9 @@ namespace eigenpy
            "Sets *this from a 3x3 rotation matrix",
            bp::return_self<>())
       .def("toRotationMatrix",
-//           bp::arg("self"),
            &AngleAxis::toRotationMatrix,
-           "Constructs and returns an equivalent 3x3 rotation matrix.")
+//           bp::arg("self"),
+           "Constructs and returns an equivalent rotation matrix.")
       .def("matrix",&AngleAxis::matrix,
            bp::arg("self"),
            "Returns an equivalent rotation matrix.")

--- a/include/eigenpy/eigen-from-python.hpp
+++ b/include/eigenpy/eigen-from-python.hpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2014-2020 CNRS INRIA
+// Copyright (c) 2014-2022 CNRS INRIA
 //
 
 #ifndef __eigenpy_eigen_from_python_hpp__
@@ -11,6 +11,36 @@
 #include "eigenpy/scalar-conversion.hpp"
 
 #include <boost/python/converter/rvalue_from_python_data.hpp>
+
+namespace eigenpy
+{
+
+template<typename C>
+struct expected_pytype_for_arg {};
+
+template<typename Scalar, int Rows, int Cols, int Options, int MaxRows, int MaxCols>
+struct expected_pytype_for_arg<Eigen::Matrix< Scalar, Rows, Cols, Options, MaxRows, MaxCols> >
+{
+  static PyTypeObject const *get_pytype()
+  {
+    PyTypeObject const * py_type = eigenpy::getPyArrayType();
+    return py_type;
+  }
+};
+
+}
+
+namespace boost {
+namespace python {
+namespace converter {
+
+template<typename Scalar, int Rows, int Cols, int Options, int MaxRows, int MaxCols>
+struct expected_pytype_for_arg<Eigen::Matrix< Scalar, Rows, Cols, Options, MaxRows, MaxCols> >
+: eigenpy::expected_pytype_for_arg<Eigen::Matrix< Scalar, Rows, Cols, Options, MaxRows, MaxCols> >
+{
+};
+
+}}}
 
 namespace eigenpy
 {
@@ -427,7 +457,12 @@ namespace eigenpy
   {
     bp::converter::registry::push_back
     (reinterpret_cast<void *(*)(_object *)>(&EigenFromPy::convertible),
-     &EigenFromPy::construct,bp::type_id<MatType>());
+     &EigenFromPy::construct,
+     bp::type_id<MatType>()
+#ifndef BOOST_PYTHON_NO_PY_SIGNATURES
+     ,&eigenpy::expected_pytype_for_arg<MatType>::get_pytype
+#endif
+     );
   }
   
   template<typename MatType>
@@ -453,7 +488,7 @@ namespace eigenpy
       // Add conversion to Eigen::Ref<MatType>
       typedef Eigen::Ref<MatType> RefType;
       EigenFromPy<RefType>::registration();
-      
+
       // Add conversion to Eigen::Ref<MatType>
       typedef const Eigen::Ref<const MatType> ConstRefType;
       EigenFromPy<ConstRefType>::registration();
@@ -471,7 +506,12 @@ namespace eigenpy
     {
       bp::converter::registry::push_back
       (reinterpret_cast<void *(*)(_object *)>(&EigenFromPy::convertible),
-       &EigenFromPy::construct,bp::type_id<Base>());
+       &EigenFromPy::construct,
+       bp::type_id<Base>()
+#ifndef BOOST_PYTHON_NO_PY_SIGNATURES
+       ,&eigenpy::expected_pytype_for_arg<MatType>::get_pytype
+#endif
+       );
     }
   };
     
@@ -485,7 +525,12 @@ namespace eigenpy
     {
       bp::converter::registry::push_back
       (reinterpret_cast<void *(*)(_object *)>(&EigenFromPy::convertible),
-       &EigenFromPy::construct,bp::type_id<Base>());
+       &EigenFromPy::construct,
+       bp::type_id<Base>()
+#ifndef BOOST_PYTHON_NO_PY_SIGNATURES
+       ,&eigenpy::expected_pytype_for_arg<MatType>::get_pytype
+#endif
+       );
     }
   };
     
@@ -499,7 +544,12 @@ namespace eigenpy
     {
       bp::converter::registry::push_back
       (reinterpret_cast<void *(*)(_object *)>(&EigenFromPy::convertible),
-       &EigenFromPy::construct,bp::type_id<Base>());
+       &EigenFromPy::construct,
+       bp::type_id<Base>()
+#ifndef BOOST_PYTHON_NO_PY_SIGNATURES
+       ,&eigenpy::expected_pytype_for_arg<MatType>::get_pytype
+#endif
+       );
     }
   };
 
@@ -526,7 +576,12 @@ namespace eigenpy
     {
       bp::converter::registry::push_back
       (reinterpret_cast<void *(*)(_object *)>(&EigenFromPy::convertible),
-       &eigen_from_py_construct<RefType>,bp::type_id<RefType>());
+       &eigen_from_py_construct<RefType>,
+       bp::type_id<RefType>()
+#ifndef BOOST_PYTHON_NO_PY_SIGNATURES
+       ,&eigenpy::expected_pytype_for_arg<MatType>::get_pytype
+#endif
+       );
     }
   };
 
@@ -546,7 +601,12 @@ namespace eigenpy
     {
       bp::converter::registry::push_back
       (reinterpret_cast<void *(*)(_object *)>(&EigenFromPy::convertible),
-       &eigen_from_py_construct<ConstRefType>,bp::type_id<ConstRefType>());
+       &eigen_from_py_construct<ConstRefType>,
+       bp::type_id<ConstRefType>()
+#ifndef BOOST_PYTHON_NO_PY_SIGNATURES
+       ,&eigenpy::expected_pytype_for_arg<MatType>::get_pytype
+#endif
+       );
     }
   };
 #endif

--- a/include/eigenpy/eigen-to-python.hpp
+++ b/include/eigenpy/eigen-to-python.hpp
@@ -80,6 +80,11 @@ namespace eigenpy
       // Create an instance (either np.array or np.matrix)
       return NumpyType::make(pyArray).ptr();
     }
+    
+    static PyTypeObject const *get_pytype()
+    {
+      return getPyArrayType();
+    }
   };
 
   template<typename MatType, int Options, typename Stride, typename _Scalar>
@@ -110,6 +115,11 @@ namespace eigenpy
       // Create an instance (either np.array or np.matrix)
       return NumpyType::make(pyArray).ptr();
     }
+    
+    static PyTypeObject const *get_pytype()
+    {
+      return getPyArrayType();
+    }
   };
 
   template<typename MatType>
@@ -117,7 +127,7 @@ namespace eigenpy
   {
     static void registration()
     {
-      bp::to_python_converter<MatType,EigenToPy<MatType> >();
+      bp::to_python_converter<MatType,EigenToPy<MatType>, true>();
     }
   };
 }

--- a/include/eigenpy/numpy.hpp
+++ b/include/eigenpy/numpy.hpp
@@ -62,9 +62,10 @@ namespace eigenpy
 
 }
 
-#if defined _WIN32 || defined __CYGWIN__
+
 namespace eigenpy
 {
+#if defined _WIN32 || defined __CYGWIN__
   EIGENPY_DLLAPI bool call_PyArray_Check(PyObject *);
 
   EIGENPY_DLLAPI PyObject* call_PyArray_SimpleNew(int nd, npy_intp * shape, int np_type);
@@ -86,19 +87,59 @@ namespace eigenpy
   EIGENPY_DLLAPI PyArray_Descr * call_PyArray_MinScalarType(PyArrayObject *arr);
 
   EIGENPY_DLLAPI int call_PyArray_RegisterCastFunc(PyArray_Descr* descr, int totype, PyArray_VectorUnaryFunc* castfunc);
-}
 #else
-  #define call_PyArray_Check(py_obj) PyArray_Check(py_obj)
-  #define call_PyArray_SimpleNew PyArray_SimpleNew
-  #define call_PyArray_New(py_type_ptr,nd,shape,np_type,data_ptr,options) \
-    PyArray_New(py_type_ptr,nd,shape,np_type,NULL,data_ptr,0,options,NULL)
-  #define getPyArrayType() &PyArray_Type
-  #define call_PyArray_DescrFromType(typenum) PyArray_DescrFromType(typenum)
-  #define call_PyArray_MinScalarType(py_arr) PyArray_MinScalarType(py_arr)
-  #define call_PyArray_InitArrFuncs(funcs) PyArray_InitArrFuncs(funcs)
-  #define call_PyArray_RegisterDataType(dtype) PyArray_RegisterDataType(dtype)
-  #define call_PyArray_RegisterCanCast(descr,totype,scalar) PyArray_RegisterCanCast(descr,totype,scalar)
-  #define call_PyArray_RegisterCastFunc(descr,totype,castfunc) PyArray_RegisterCastFunc(descr,totype,castfunc)
+inline bool call_PyArray_Check(PyObject * py_obj)
+{
+  return PyArray_Check(py_obj);
+}
+
+inline PyObject* call_PyArray_SimpleNew(int nd, npy_intp * shape, int np_type)
+{
+  return PyArray_SimpleNew(nd,shape,np_type);
+}
+
+inline PyObject* call_PyArray_New(PyTypeObject * py_type_ptr, int nd, npy_intp * shape, int np_type, void * data_ptr, int options)
+{
+  return PyArray_New(py_type_ptr,nd,shape,np_type,NULL,data_ptr,0,options,NULL);
+}
+
+inline int call_PyArray_ObjectType(PyObject * obj, int val)
+{
+  return PyArray_ObjectType(obj,val);
+}
+
+inline PyTypeObject * getPyArrayType() { return &PyArray_Type; }
+
+inline PyArray_Descr * call_PyArray_DescrFromType(int typenum)
+{
+  return PyArray_DescrFromType(typenum);
+}
+
+inline void call_PyArray_InitArrFuncs(PyArray_ArrFuncs * funcs)
+{
+  PyArray_InitArrFuncs(funcs);
+}
+
+inline int call_PyArray_RegisterDataType(PyArray_Descr * dtype)
+{
+  return PyArray_RegisterDataType(dtype);
+}
+
+inline PyArray_Descr * call_PyArray_MinScalarType(PyArrayObject * arr)
+{
+  return PyArray_MinScalarType(arr);
+}
+
+inline int call_PyArray_RegisterCanCast(PyArray_Descr *descr, int totype, NPY_SCALARKIND scalar)
+{
+  return PyArray_RegisterCanCast(descr,totype,scalar);
+}
+
+inline int call_PyArray_RegisterCastFunc(PyArray_Descr* descr, int totype, PyArray_VectorUnaryFunc* castfunc)
+{
+  return PyArray_RegisterCastFunc(descr,totype,castfunc);
+}
 #endif
+}
 
 #endif // ifndef __eigenpy_numpy_hpp__

--- a/include/eigenpy/quaternion.hpp
+++ b/include/eigenpy/quaternion.hpp
@@ -171,7 +171,7 @@ namespace eigenpy
            "Returns an equivalent 3x3 rotation matrix. Similar to toRotationMatrix.")
       .def("toRotationMatrix",&Quaternion::toRotationMatrix,
 //           bp::arg("self"), // Bug in Boost.Python
-           "Returns an equivalent 3x3 rotation matrix.")
+           "Returns an equivalent rotation matrix.")
       
       .def("setFromTwoVectors",&setFromTwoVectors,((bp::arg("self"),bp::arg("a"),bp::arg("b"))),
            "Set *this to be the quaternion which transforms a into b through a rotation."

--- a/python/main.cpp
+++ b/python/main.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright 2014-2019, CNRS
- * Copyright 2018-2021, INRIA
+ * Copyright 2018-2022, INRIA
  */
 
 #include "eigenpy/eigenpy.hpp"
@@ -48,12 +48,8 @@ BOOST_PYTHON_MODULE(eigenpy_pywrap)
     using namespace Eigen;
 
     bp::def("is_approx",(bool (*)(const Eigen::MatrixBase<MatrixXd> &, const Eigen::MatrixBase<MatrixXd> &, const double &))&is_approx<MatrixXd,MatrixXd>,
-            bp::args("A","B","prec"),
+            (bp::arg("A"),bp::arg("B"),bp::arg("prec") = 1e-12),
             "Returns True if A is approximately equal to B, within the precision determined by prec.");
-
-    bp::def("is_approx",(bool (*)(const Eigen::MatrixBase<MatrixXd> &, const Eigen::MatrixBase<MatrixXd> &))&is_approx<MatrixXd,MatrixXd>,
-            bp::args("A","B"),
-            "Returns True if A is approximately equal to B.");
   }
 
   exposeDecompositions();


### PR DESCRIPTION
This PR allows exposing the name of the objects in the Boost.Python doc.