### PR TITLE
numpy: avoid deprecated header

### DIFF
--- a/include/eigenpy/numpy.hpp
+++ b/include/eigenpy/numpy.hpp
@@ -16,7 +16,7 @@
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #endif
 
-#include <numpy/noprefix.h>
+#include <numpy/ndarrayobject.h>
 #include <numpy/ufuncobject.h>
 
 #if defined _WIN32 || defined __CYGWIN__


### PR DESCRIPTION
The `numpy/noprefix.h` array is deprecated and should be removed (it can create problems with some libraries when using recent C++ standards)

- [x] checked tests still pass

Cross-reference: https://github.com/numpy/numpy/pull/12402
Same fix applied in: 
https://github.com/matplotlib/matplotlib/pull/12976