### PR TITLE
test/eigen_ref: test using Eigen::Ref as data member

### DIFF
--- a/unittest/eigen_ref.cpp
+++ b/unittest/eigen_ref.cpp
@@ -86,10 +86,9 @@ struct modify_wrap : modify_block, bp::wrapper<modify_block> {
   void call(Eigen::Ref<MatrixXd> mat) { this->get_override("call")(mat); }
 };
 
-struct has_ref_member
-{
+struct has_ref_member {
   MatrixXd J;
-  Eigen::Ref<MatrixXd> Jref; 
+  Eigen::Ref<MatrixXd> Jref;
   has_ref_member() : J(4, 4), Jref(J.topRightCorner(3, 3)) { J.setZero(); }
 };
 
@@ -129,8 +128,10 @@ BOOST_PYTHON_MODULE(eigen_ref) {
 
   bp::class_<has_ref_member, boost::noncopyable>("has_ref_member", bp::init<>())
       .def_readonly("J", &has_ref_member::J)
-      .add_property("Jref", bp::make_getter(&has_ref_member::Jref,
-                                            bp::return_value_policy<bp::return_by_value>()));
-                                            // can't return Eigen::Ref by reference but by value
-                                            // (def_readonly creates a by-reference getter)
+      .add_property(
+          "Jref",
+          bp::make_getter(&has_ref_member::Jref,
+                          bp::return_value_policy<bp::return_by_value>()));
+  // can't return Eigen::Ref by reference but by value
+  // (def_readonly creates a by-reference getter)
 }

--- a/unittest/eigen_ref.cpp
+++ b/unittest/eigen_ref.cpp
@@ -86,6 +86,13 @@ struct modify_wrap : modify_block, bp::wrapper<modify_block> {
   void call(Eigen::Ref<MatrixXd> mat) { this->get_override("call")(mat); }
 };
 
+struct has_ref_member
+{
+  MatrixXd J;
+  Eigen::Ref<MatrixXd> Jref; 
+  has_ref_member() : J(4, 4), Jref(J.topRightCorner(3, 3)) { J.setZero(); }
+};
+
 BOOST_PYTHON_MODULE(eigen_ref) {
   namespace bp = boost::python;
   eigenpy::enableEigenPy();
@@ -119,4 +126,11 @@ BOOST_PYTHON_MODULE(eigen_ref) {
       .def_readonly("J", &modify_block::J)
       .def("modify", &modify_block::modify)
       .def("call", bp::pure_virtual(&modify_wrap::call));
+
+  bp::class_<has_ref_member, boost::noncopyable>("has_ref_member", bp::init<>())
+      .def_readonly("J", &has_ref_member::J)
+      .add_property("Jref", bp::make_getter(&has_ref_member::Jref,
+                                            bp::return_value_policy<bp::return_by_value>()));
+                                            // can't return Eigen::Ref by reference but by value
+                                            // (def_readonly creates a by-reference getter)
 }

--- a/unittest/python/test_eigen_ref.py
+++ b/unittest/python/test_eigen_ref.py
@@ -62,6 +62,14 @@ def test(mat):
 
     assert np.array_equal(Jref, modify.J)
 
+    hasref = has_ref_member()
+    A = np.ones((3, 3)) / 2
+    hasref.Jref[:, :] = A
+    J_true = np.zeros((4, 4))
+    J_true[:3, 1:] = A
+
+    assert np.array_equal(hasref.J, J_true)
+
 
 rows = 10
 cols = 30


### PR DESCRIPTION
This commit adds a test where the user exposes a struct with an `Eigen::Ref` data member and shows how to expose it using the right `boost::python::return_value_policy`.