### PR TITLE
Fix for Refs to dynamic (1, N) blocks

### DIFF
--- a/include/eigenpy/numpy-allocator.hpp
+++ b/include/eigenpy/numpy-allocator.hpp
@@ -70,8 +70,7 @@ struct NumpyAllocator<Eigen::Ref<MatType, Options, Stride> > {
 
     if (NumpyType::sharedMemory()) {
       const int Scalar_type_code = Register::getTypeCode<Scalar>();
-      const npy_int R = (npy_int)mat.rows();
-      const bool reverse_strides = MatType::IsRowMajor || (R == 1);
+      const bool reverse_strides = MatType::IsRowMajor || (mat.rows() == 1);
       Eigen::DenseIndex inner_stride = reverse_strides ? mat.outerStride()
                                                        : mat.innerStride(),
                         outer_stride = reverse_strides ? mat.innerStride()

--- a/include/eigenpy/numpy-allocator.hpp
+++ b/include/eigenpy/numpy-allocator.hpp
@@ -70,11 +70,12 @@ struct NumpyAllocator<Eigen::Ref<MatType, Options, Stride> > {
 
     if (NumpyType::sharedMemory()) {
       const int Scalar_type_code = Register::getTypeCode<Scalar>();
-
-      Eigen::DenseIndex inner_stride = MatType::IsRowMajor ? mat.outerStride()
-                                                           : mat.innerStride(),
-                        outer_stride = MatType::IsRowMajor ? mat.innerStride()
-                                                           : mat.outerStride();
+      const npy_int R = (npy_int)mat.rows();
+      const bool reverse_strides = MatType::IsRowMajor || (R == 1);
+      Eigen::DenseIndex inner_stride = reverse_strides ? mat.outerStride()
+                                                       : mat.innerStride(),
+                        outer_stride = reverse_strides ? mat.innerStride()
+                                                       : mat.outerStride();
 
       const int elsize = call_PyArray_DescrFromType(Scalar_type_code)->elsize;
       npy_intp strides[2] = {elsize * inner_stride, elsize * outer_stride};

--- a/include/eigenpy/numpy-allocator.hpp
+++ b/include/eigenpy/numpy-allocator.hpp
@@ -135,10 +135,11 @@ struct NumpyAllocator<const Eigen::Ref<const MatType, Options, Stride> > {
     if (NumpyType::sharedMemory()) {
       const int Scalar_type_code = Register::getTypeCode<Scalar>();
 
-      Eigen::DenseIndex inner_stride = MatType::IsRowMajor ? mat.outerStride()
-                                                           : mat.innerStride(),
-                        outer_stride = MatType::IsRowMajor ? mat.innerStride()
-                                                           : mat.outerStride();
+      const bool reverse_strides = MatType::IsRowMajor || (mat.rows() == 1);
+      Eigen::DenseIndex inner_stride = reverse_strides ? mat.outerStride()
+                                                       : mat.innerStride(),
+                        outer_stride = reverse_strides ? mat.innerStride()
+                                                       : mat.outerStride();
 
       const int elsize = call_PyArray_DescrFromType(Scalar_type_code)->elsize;
       npy_intp strides[2] = {elsize * inner_stride, elsize * outer_stride};

--- a/unittest/python/test_eigen_ref.py
+++ b/unittest/python/test_eigen_ref.py
@@ -35,17 +35,28 @@ def test(mat):
     assert np.all(mat[:2, :3] == np.ones((2, 3)))
 
     mat.fill(0.0)
+    mat[:, :] = np.arange(rows * cols).reshape(rows, cols)
+    printMatrix(mat)
+    mat0 = mat.copy()
     mat_as_C_order = np.array(mat, order="F")
-    getBlock(mat_as_C_order, 0, 0, 3, 2)[:, :] = 1.0
+    for i, rowsize in ([0, 3], [1, 1]):
+        print("taking block [{}:{}, {}:{}]".format(i, rowsize+i, 0, 2))
+        B = getBlock(mat_as_C_order, i, 0, rowsize, 2)
+        lhs = mat_as_C_order[i:rowsize + i, :2]
+        print("should be:\n{}\ngot:\n{}".format(lhs, B))
+        assert np.array_equal(lhs, B)
+    
+        B[:] = 1.0
+        rhs = np.ones((rowsize, 2))
+        assert np.array_equal(mat_as_C_order[i:rowsize+i, :2], rhs)
 
-    assert np.all(mat_as_C_order[:3, :2] == np.ones((3, 2)))
+        mat_as_C_order[:, :] = mat0
 
-    mat_as_C_order[:3, :2] = 0.0
     mat_copy = mat_as_C_order.copy()
     editBlock(mat_as_C_order, 0, 0, 3, 2)
     mat_copy[:3, :2] = np.arange(6).reshape(3, 2)
 
-    assert np.all(mat_as_C_order == mat_copy)
+    assert np.array_equal(mat_as_C_order, mat_copy)
 
     class ModifyBlockImpl(modify_block):
         def __init__(self):

--- a/unittest/python/test_eigen_ref.py
+++ b/unittest/python/test_eigen_ref.py
@@ -39,16 +39,16 @@ def test(mat):
     printMatrix(mat)
     mat0 = mat.copy()
     mat_as_C_order = np.array(mat, order="F")
-    for i, rowsize in ([0, 3], [1, 1]):
-        print("taking block [{}:{}, {}:{}]".format(i, rowsize+i, 0, 2))
-        B = getBlock(mat_as_C_order, i, 0, rowsize, 2)
-        lhs = mat_as_C_order[i:rowsize + i, :2]
+    for i, rowsize, colsize in ([0, 3, 2], [1, 1, 2], [0, 3, 1]):
+        print("taking block [{}:{}, {}:{}]".format(i, rowsize+i, 0, colsize))
+        B = getBlock(mat_as_C_order, i, 0, rowsize, colsize)
+        lhs = mat_as_C_order[i:rowsize + i, :colsize]
         print("should be:\n{}\ngot:\n{}".format(lhs, B))
-        assert np.array_equal(lhs, B)
+        assert np.array_equal(lhs, B.reshape(rowsize, colsize))
     
         B[:] = 1.0
-        rhs = np.ones((rowsize, 2))
-        assert np.array_equal(mat_as_C_order[i:rowsize+i, :2], rhs)
+        rhs = np.ones((rowsize, colsize))
+        assert np.array_equal(mat_as_C_order[i:rowsize+i, :colsize], rhs)
 
         mat_as_C_order[:, :] = mat0
 

--- a/unittest/python/test_eigen_ref.py
+++ b/unittest/python/test_eigen_ref.py
@@ -40,15 +40,15 @@ def test(mat):
     mat0 = mat.copy()
     mat_as_C_order = np.array(mat, order="F")
     for i, rowsize, colsize in ([0, 3, 2], [1, 1, 2], [0, 3, 1]):
-        print("taking block [{}:{}, {}:{}]".format(i, rowsize+i, 0, colsize))
+        print("taking block [{}:{}, {}:{}]".format(i, rowsize + i, 0, colsize))
         B = getBlock(mat_as_C_order, i, 0, rowsize, colsize)
-        lhs = mat_as_C_order[i:rowsize + i, :colsize]
+        lhs = mat_as_C_order[i : rowsize + i, :colsize]
         print("should be:\n{}\ngot:\n{}".format(lhs, B))
         assert np.array_equal(lhs, B.reshape(rowsize, colsize))
-    
+
         B[:] = 1.0
         rhs = np.ones((rowsize, colsize))
-        assert np.array_equal(mat_as_C_order[i:rowsize+i, :colsize], rhs)
+        assert np.array_equal(mat_as_C_order[i : rowsize + i, :colsize], rhs)
 
         mat_as_C_order[:, :] = mat0
 


### PR DESCRIPTION
This PR:

* adds tests where user takes (1,n) or (n,1) blocks of matrices as `Eigen::Ref` and returns them to NumPy
* fixes the corner case where (n,1) was taken
* builds on fix for `RowMajor` in 471b8d65bff9240239e6d490100d97074a429952 