### PR TITLE
ROS2/Colcon integration for AMENT_PREFIX_PATH and PYTHONPATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,6 +239,10 @@ install(FILES package.xml DESTINATION share/eigenpy)
 # Allows Colcon to find non-Ament packages when using workspace underlays
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/share/ament_index/resource_index/packages/${PROJECT_NAME} "")
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/share/ament_index/resource_index/packages/${PROJECT_NAME} DESTINATION share/ament_index/resource_index/packages)
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/share/${PROJECT_NAME}/hook/ament_prefix_path.dsv "prepend-non-duplicate;AMENT_PREFIX_PATH;")
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/share/${PROJECT_NAME}/hook/ament_prefix_path.dsv DESTINATION share/${PROJECT_NAME}/hook)
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/share/${PROJECT_NAME}/hook/python_path.dsv "prepend-non-duplicate;PYTHONPATH;${PYTHON_SITELIB}")
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/share/${PROJECT_NAME}/hook/python_path.dsv DESTINATION share/${PROJECT_NAME}/hook)
 
 # ----------------------------------------------------
 # --- PYTHON LIBRARY ---------------------------------

--- a/colcon.pkg
+++ b/colcon.pkg
@@ -1,0 +1,6 @@
+{
+    "hooks": [
+        "share/eigenpy/hook/ament_prefix_path.dsv",
+        "share/eigenpy/hook/python_path.dsv"
+    ]
+}


### PR DESCRIPTION
Required in order for PYTHONPATH to be set up correctly after sourcing a workspace built with colcon