### PR TITLE
Fix python numpy linking error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ if(CMAKE_CROSSCOMPILING)
 else()
   set(PYTHON_COMPONENTS Interpreter Development.Module NumPy)
 endif()
+set(PYTHON_EXPORT_DEPENDENCY ON)
 FINDPYTHON()
 
 IF(WIN32)


### PR DESCRIPTION
Depends on https://github.com/jrl-umi3218/jrl-cmakemodules/pull/523

Alternative for #294 