### PR TITLE
[CI] Always run PRERELEASE tests

### DIFF
--- a/.github/workflows/ros_ci.yml
+++ b/.github/workflows/ros_ci.yml
@@ -11,14 +11,16 @@ jobs:
     strategy:
       matrix:
         env:
-          - {ROS_DISTRO: melodic}
-          - {ROS_DISTRO: noetic, BUILDER: catkin_tools}
+          - {ROS_DISTRO: melodic, PRERELEASE: false}
+          - {ROS_DISTRO: noetic}
           - {ROS_DISTRO: foxy}
           - {ROS_DISTRO: galactic}
-          - {ROS_DISTRO: foxy, PRERELEASE: true}
-          - {ROS_DISTRO: galactic, PRERELEASE: true}
+          - {ROS_DISTRO: rolling}
+          - {ROS_DISTRO: humble}
     env:
       CCACHE_DIR: /github/home/.ccache # Enable ccache
+      PRERELEASE: true
+      BUILDER: colcon
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Our current CI configuration only ran prerelease tests for ROS2. We recently had a CMake breakage for Python2

@nim65s Can you please look into why the new CMake does not correctly configure for Python2 on 18.04?

Cf.
https://github.com/ros/rosdistro/pull/34135#issuecomment-1221034543
https://github.com/stack-of-tasks/eigenpy-ros-release/issues/4