### PR TITLE
relocatable eigenpy.pc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,6 +287,3 @@ add_subdirectory(python)
 add_subdirectory(unittest)
 
 pkg_config_append_libs(${PROJECT_NAME})
-pkg_config_append_cflags("-I${PYTHON_INCLUDE_DIRS}")
-pkg_config_append_cflags("-I${NUMPY_INCLUDE_DIRS}")
-pkg_config_append_boost_libs(${BOOST_COMPONENTS})


### PR DESCRIPTION
Hi,

When some downstream packages use pkg-config to use eigenpy, they are not relocatable anymore. Here is a tested fix for that.

The downside of removing this is that people using pkg-config to quickly compile something will need to add boost manually, but since boost doesn't provide any .pc file, we're doomed.