### PR TITLE
Modify stride assertion in `numpy-map.hpp` to be valid for empty vector

### DIFF
--- a/include/eigenpy/numpy-map.hpp
+++ b/include/eigenpy/numpy-map.hpp
@@ -158,7 +158,7 @@ struct NumpyMapTraits<MatType, InputScalar, AlignmentValue, Stride, true> {
       rowMajor = (PyArray_DIMS(pyArray)[0] > PyArray_DIMS(pyArray)[1]) ? 0 : 1;
 
     assert((PyArray_DIMS(pyArray)[rowMajor] < INT_MAX) &&
-           (PyArray_STRIDE(pyArray, rowMajor)));
+           (PyArray_STRIDE(pyArray, rowMajor) < INT_MAX));
     const int R = (int)PyArray_DIMS(pyArray)[rowMajor];
     const long int itemsize = PyArray_ITEMSIZE(pyArray);
     const int stride = (int)PyArray_STRIDE(pyArray, rowMajor) / (int)itemsize;

--- a/include/eigenpy/numpy-map.hpp
+++ b/include/eigenpy/numpy-map.hpp
@@ -157,8 +157,7 @@ struct NumpyMapTraits<MatType, InputScalar, AlignmentValue, Stride, true> {
     else
       rowMajor = (PyArray_DIMS(pyArray)[0] > PyArray_DIMS(pyArray)[1]) ? 0 : 1;
 
-    assert((PyArray_DIMS(pyArray)[rowMajor] < INT_MAX) &&
-           (PyArray_STRIDE(pyArray, rowMajor) < INT_MAX));
+    assert(PyArray_DIMS(pyArray)[rowMajor] < INT_MAX);
     const int R = (int)PyArray_DIMS(pyArray)[rowMajor];
     const long int itemsize = PyArray_ITEMSIZE(pyArray);
     const int stride = (int)PyArray_STRIDE(pyArray, rowMajor) / (int)itemsize;

--- a/unittest/python/test_matrix.py
+++ b/unittest/python/test_matrix.py
@@ -6,38 +6,34 @@ import matrix as eigenpy
 verbose = True
 
 if verbose:
-    print("===> From empty MatrixXd to Py")
+    print("===> From empty MatrixXd to Py", flush=True)
 M = eigenpy.emptyMatrix()
 assert M.shape == (0, 0)
 
 if verbose:
-    print("===> From empty VectorXd to Py")
+    print("===> From empty VectorXd to Py", flush=True)
 v = eigenpy.emptyVector()
 assert v.shape == (0,)
 
 if verbose:
-    print("===> From MatrixXd to Py")
+    print("===> From MatrixXd to Py", flush=True)
 M = eigenpy.naturals(3, 3, verbose)
 Mcheck = np.reshape(np.array(range(9), np.double), [3, 3])
 assert np.array_equal(Mcheck, M)
 
 if verbose:
-    print("===> From Matrix3d to Py")
+    print("===> From Matrisx3d to Py", flush=True)
 M33 = eigenpy.naturals33(verbose)
 assert np.array_equal(Mcheck, M33)
 
 if verbose:
-    print("===> From VectorXd to Py")
+    print("===> From VectorXd to Py", flush=True)
 v = eigenpy.naturalsX(3, verbose)
 vcheck = np.array(range(3), np.double).T
 assert np.array_equal(vcheck, v)
 
 if verbose:
-    print("===> From Py to Eigen::MatrixXd")
-if verbose:
-    print("===> From Py to Eigen::MatrixXd")
-if verbose:
-    print("===> From Py to Eigen::MatrixXd")
+    print("===> From Py to Eigen::MatrixXd", flush=True)
 Mref = np.reshape(np.array(range(64), np.double), [8, 8])
 
 # Test base function
@@ -49,27 +45,27 @@ Mref_from_plain = eigenpy.plain(Mref)
 assert np.array_equal(Mref, Mref_from_plain)
 
 if verbose:
-    print("===> Matrix 8x8")
+    print("===> Matrix 8x8", flush=True)
 M = Mref
 assert np.array_equal(M, eigenpy.reflex(M, verbose))
 
 if verbose:
-    print("===> Block 0:3x0:3")
+    print("===> Block 0:3x0:3", flush=True)
 M = Mref[0:3, 0:3]
 assert np.array_equal(M, eigenpy.reflex(M, verbose))
 
 if verbose:
-    print("===> Block 1:3x1:3")
+    print("===> Block 1:3x1:3", flush=True)
 M = Mref[1:3, 1:3]
 assert np.array_equal(M, eigenpy.reflex(M, verbose))
 
 if verbose:
-    print("===> Block 1:5:2x1:5:2")
+    print("===> Block 1:5:2x1:5:2", flush=True)
 M = Mref[1:5:2, 1:5:2]
 assert np.array_equal(M, eigenpy.reflex(M, verbose))
 
 if verbose:
-    print("===> Block 1:8:3x1:5")
+    print("===> Block 1:8:3x1:5", flush=True)
 M = Mref[1:8:3, 1:5]
 assert np.array_equal(M, eigenpy.reflex(M, verbose))
 
@@ -79,55 +75,41 @@ M = Mref[1:8:3, 0:6:2].T
 assert np.array_equal(M, eigenpy.reflex(M, verbose))
 
 if verbose:
-    print("===> Block Vector 1x0:6:2")
+    print("===> Block Vector 1x0:6:2", flush=True)
 M = Mref[1:2, 0:6:2]
 assert np.array_equal(M.squeeze(), eigenpy.reflex(M, verbose))
 
 if verbose:
-    print("===> Block Vector 1x0:6:2 tanspose")
+    print("===> Block Vector 1x0:6:2 tanspose", flush=True)
 M = Mref[1:2, 0:6:2].T
 assert np.array_equal(M.squeeze(), eigenpy.reflex(M, verbose))
 
 if verbose:
-    print("===> Block Vector 0:6:2x1")
+    print("===> Block Vector 0:6:2x1", flush=True)
 M = Mref[0:6:2, 1:2]
 assert np.array_equal(M.squeeze(), eigenpy.reflex(M, verbose))
 
 if verbose:
-    print("===> Block Vector 0:6:2x1 tanspose")
+    print("===> Block Vector 0:6:2x1 tanspose", flush=True)
 M = Mref[0:6:2, 1:2].T
 assert np.array_equal(M.squeeze(), eigenpy.reflex(M, verbose))
 
 if verbose:
-    print("===> From Py to Eigen::VectorXd")
-if verbose:
-    print("===> From Py to Eigen::VectorXd")
-if verbose:
-    print("===> From Py to Eigen::VectorXd")
-
-if verbose:
-    print("===> Block Vector 0:6:2x1 1 dim")
+    print("===> Block Vector 0:6:2x1 1 dim", flush=True)
 M = Mref[0:6:2, 1].T
 # TODO
 # assert( np.array_equal(M.T,eigenpy.reflexV(M,verbose)) );
 
 if verbose:
-    print("===> Block Vector 0:6:2x1")
+    print("===> Block Vector 0:6:2x1", flush=True)
 M = Mref[0:6:2, 1:2]
 assert np.array_equal(M.squeeze(), eigenpy.reflexV(M, verbose))
 
 if verbose:
-    print("===> Block Vector 0:6:2x1 transpose")
+    print("===> Block Vector 0:6:2x1 transpose", flush=True)
 M = Mref[0:6:2, 1:2].T
 # TODO
 # assert( np.array_equal(M.T,eigenpy.reflexV(M,verbose)) );
-
-if verbose:
-    print("===> From Py to Eigen::Matrix3d")
-if verbose:
-    print("===> From Py to Eigen::Matrix3d")
-if verbose:
-    print("===> From Py to Eigen::Matrix3d")
 
 if verbose:
     print("===> Block Vector 0:3x0:6:2 ")
@@ -142,13 +124,6 @@ M = Mref[0:3, 0:6].T
 # assert( np.array_equal(M,eigenpy.reflex33(M,verbose)) );
 # except eigenpy.Exception as e:
 # if verbose: print("As expected, got the following /ROW/ error:", e.message)
-
-if verbose:
-    print("===> From Py to Eigen::Vector3d")
-if verbose:
-    print("===> From Py to Eigen::Vector3d")
-if verbose:
-    print("===> From Py to Eigen::Vector3d")
 
 # TODO
 # M = Mref[0:3,1:2]

--- a/unittest/python/test_matrix.py
+++ b/unittest/python/test_matrix.py
@@ -6,34 +6,38 @@ import matrix as eigenpy
 verbose = True
 
 if verbose:
-    print("===> From empty MatrixXd to Py", flush=True)
+    print("===> From empty MatrixXd to Py")
 M = eigenpy.emptyMatrix()
 assert M.shape == (0, 0)
 
 if verbose:
-    print("===> From empty VectorXd to Py", flush=True)
+    print("===> From empty VectorXd to Py")
 v = eigenpy.emptyVector()
 assert v.shape == (0,)
 
 if verbose:
-    print("===> From MatrixXd to Py", flush=True)
+    print("===> From MatrixXd to Py")
 M = eigenpy.naturals(3, 3, verbose)
 Mcheck = np.reshape(np.array(range(9), np.double), [3, 3])
 assert np.array_equal(Mcheck, M)
 
 if verbose:
-    print("===> From Matrisx3d to Py", flush=True)
+    print("===> From Matrix3d to Py")
 M33 = eigenpy.naturals33(verbose)
 assert np.array_equal(Mcheck, M33)
 
 if verbose:
-    print("===> From VectorXd to Py", flush=True)
+    print("===> From VectorXd to Py")
 v = eigenpy.naturalsX(3, verbose)
 vcheck = np.array(range(3), np.double).T
 assert np.array_equal(vcheck, v)
 
 if verbose:
-    print("===> From Py to Eigen::MatrixXd", flush=True)
+    print("===> From Py to Eigen::MatrixXd")
+if verbose:
+    print("===> From Py to Eigen::MatrixXd")
+if verbose:
+    print("===> From Py to Eigen::MatrixXd")
 Mref = np.reshape(np.array(range(64), np.double), [8, 8])
 
 # Test base function
@@ -45,27 +49,27 @@ Mref_from_plain = eigenpy.plain(Mref)
 assert np.array_equal(Mref, Mref_from_plain)
 
 if verbose:
-    print("===> Matrix 8x8", flush=True)
+    print("===> Matrix 8x8")
 M = Mref
 assert np.array_equal(M, eigenpy.reflex(M, verbose))
 
 if verbose:
-    print("===> Block 0:3x0:3", flush=True)
+    print("===> Block 0:3x0:3")
 M = Mref[0:3, 0:3]
 assert np.array_equal(M, eigenpy.reflex(M, verbose))
 
 if verbose:
-    print("===> Block 1:3x1:3", flush=True)
+    print("===> Block 1:3x1:3")
 M = Mref[1:3, 1:3]
 assert np.array_equal(M, eigenpy.reflex(M, verbose))
 
 if verbose:
-    print("===> Block 1:5:2x1:5:2", flush=True)
+    print("===> Block 1:5:2x1:5:2")
 M = Mref[1:5:2, 1:5:2]
 assert np.array_equal(M, eigenpy.reflex(M, verbose))
 
 if verbose:
-    print("===> Block 1:8:3x1:5", flush=True)
+    print("===> Block 1:8:3x1:5")
 M = Mref[1:8:3, 1:5]
 assert np.array_equal(M, eigenpy.reflex(M, verbose))
 
@@ -75,41 +79,55 @@ M = Mref[1:8:3, 0:6:2].T
 assert np.array_equal(M, eigenpy.reflex(M, verbose))
 
 if verbose:
-    print("===> Block Vector 1x0:6:2", flush=True)
+    print("===> Block Vector 1x0:6:2")
 M = Mref[1:2, 0:6:2]
 assert np.array_equal(M.squeeze(), eigenpy.reflex(M, verbose))
 
 if verbose:
-    print("===> Block Vector 1x0:6:2 tanspose", flush=True)
+    print("===> Block Vector 1x0:6:2 tanspose")
 M = Mref[1:2, 0:6:2].T
 assert np.array_equal(M.squeeze(), eigenpy.reflex(M, verbose))
 
 if verbose:
-    print("===> Block Vector 0:6:2x1", flush=True)
+    print("===> Block Vector 0:6:2x1")
 M = Mref[0:6:2, 1:2]
 assert np.array_equal(M.squeeze(), eigenpy.reflex(M, verbose))
 
 if verbose:
-    print("===> Block Vector 0:6:2x1 tanspose", flush=True)
+    print("===> Block Vector 0:6:2x1 tanspose")
 M = Mref[0:6:2, 1:2].T
 assert np.array_equal(M.squeeze(), eigenpy.reflex(M, verbose))
 
 if verbose:
-    print("===> Block Vector 0:6:2x1 1 dim", flush=True)
+    print("===> From Py to Eigen::VectorXd")
+if verbose:
+    print("===> From Py to Eigen::VectorXd")
+if verbose:
+    print("===> From Py to Eigen::VectorXd")
+
+if verbose:
+    print("===> Block Vector 0:6:2x1 1 dim")
 M = Mref[0:6:2, 1].T
 # TODO
 # assert( np.array_equal(M.T,eigenpy.reflexV(M,verbose)) );
 
 if verbose:
-    print("===> Block Vector 0:6:2x1", flush=True)
+    print("===> Block Vector 0:6:2x1")
 M = Mref[0:6:2, 1:2]
 assert np.array_equal(M.squeeze(), eigenpy.reflexV(M, verbose))
 
 if verbose:
-    print("===> Block Vector 0:6:2x1 transpose", flush=True)
+    print("===> Block Vector 0:6:2x1 transpose")
 M = Mref[0:6:2, 1:2].T
 # TODO
 # assert( np.array_equal(M.T,eigenpy.reflexV(M,verbose)) );
+
+if verbose:
+    print("===> From Py to Eigen::Matrix3d")
+if verbose:
+    print("===> From Py to Eigen::Matrix3d")
+if verbose:
+    print("===> From Py to Eigen::Matrix3d")
 
 if verbose:
     print("===> Block Vector 0:3x0:6:2 ")
@@ -124,6 +142,13 @@ M = Mref[0:3, 0:6].T
 # assert( np.array_equal(M,eigenpy.reflex33(M,verbose)) );
 # except eigenpy.Exception as e:
 # if verbose: print("As expected, got the following /ROW/ error:", e.message)
+
+if verbose:
+    print("===> From Py to Eigen::Vector3d")
+if verbose:
+    print("===> From Py to Eigen::Vector3d")
+if verbose:
+    print("===> From Py to Eigen::Vector3d")
 
 # TODO
 # M = Mref[0:3,1:2]


### PR DESCRIPTION
I'm currently running into the following issue on master (v2.7.14), noted [here](https://aur.archlinux.org/packages/eigenpy#comment-881903).

```
❯ ARGS="--output-on-failure" make test 
Running tests...
/usr/bin/ctest --force-new-ctest-process --output-on-failure
Test project /home/anthony/code/aur-testing/eigenpy/build
      Start  1: matrix
 1/21 Test  #1: matrix ...........................   Passed    0.17 sec
      Start  2: geometry
 2/21 Test  #2: geometry .........................   Passed    0.16 sec
      Start  3: complex
 3/21 Test  #3: complex ..........................   Passed    0.16 sec
      Start  4: return_by_ref
 4/21 Test  #4: return_by_ref ....................   Passed    0.17 sec
      Start  5: include
 5/21 Test  #5: include ..........................   Passed    0.11 sec
      Start  6: eigen_ref
 6/21 Test  #6: eigen_ref ........................   Passed    0.17 sec
      Start  7: user_type
 7/21 Test  #7: user_type ........................   Passed    0.16 sec
      Start  8: py-matrix
 8/21 Test  #8: py-matrix ........................Subprocess aborted***Exception:   0.30 sec
python: /home/anthony/code/aur-testing/eigenpy/include/eigenpy/numpy-map.hpp:160: static eigenpy::NumpyMapTraits<MatType, InputScalar, AlignmentValue, Stride, true>::EigenMap eigenpy::NumpyMapTraits<MatType, InputScalar, AlignmentValue, Stride, true>::mapImpl(PyArrayObject*, bool) [with MatType = Eigen::Matrix<double, -1, 1>; InputScalar = double; int AlignmentValue = 0; Stride = Eigen::InnerStride<>; EigenMap = Eigen::Map<Eigen::Matrix<double, -1, 1>, 0, Eigen::InnerStride<> >; PyArrayObject = tagPyArrayObject]: Assertion `(PyArray_DIMS(pyArray)[rowMajor] < INT_MAX) && (PyArray_STRIDE(pyArray, rowMajor))' failed.

      Start  9: py-geometry
 9/21 Test  #9: py-geometry ......................   Passed    0.17 sec
      Start 10: py-complex
10/21 Test #10: py-complex .......................   Passed    0.17 sec
      Start 11: py-return-by-ref
11/21 Test #11: py-return-by-ref .................   Passed    0.17 sec
      Start 12: py-eigen-ref
12/21 Test #12: py-eigen-ref .....................   Passed    0.17 sec
      Start 13: py-user-type
13/21 Test #13: py-user-type .....................   Passed    0.18 sec
      Start 14: py-switch
14/21 Test #14: py-switch ........................   Passed    0.16 sec
      Start 15: py-dimensions
15/21 Test #15: py-dimensions ....................   Passed    0.16 sec
      Start 16: py-version
16/21 Test #16: py-version .......................   Passed    0.17 sec
      Start 17: py-eigen-solver
17/21 Test #17: py-eigen-solver ..................   Passed    1.02 sec
      Start 18: py-self-adjoint-eigen-solver
18/21 Test #18: py-self-adjoint-eigen-solver .....   Passed    0.21 sec
      Start 19: py-LLT
19/21 Test #19: py-LLT ...........................   Passed    0.18 sec
      Start 20: py-LDLT
20/21 Test #20: py-LDLT ..........................   Passed    0.18 sec
      Start 21: py-MINRES
21/21 Test #21: py-MINRES ........................   Passed    0.17 sec

95% tests passed, 1 tests failed out of 21

Total Test time (real) =   4.54 sec

The following tests FAILED:
          8 - py-matrix (Subprocess aborted)
Errors while running CTest
make: *** [Makefile:74: test] Error 8
```

With a little bit of debugging, I found that the `PyArray_STRIDE(pyArray, rowMajor)` is `0`, which triggers the assertion. I noticed that a similar condition in `NumpyMapTraits::mapImpl` asserts that the stride is less than int max, which is likely what was meant here. 

https://github.com/stack-of-tasks/eigenpy/blob/e491c961c24e5860e21c63a596a7e8954598e51a/include/eigenpy/numpy-map.hpp#L77-L78

Since the assertion terminates the python subprocess unexpectedly, the printing output from the test wasn't very helpful. I added flush calls and found out that it was failing on `rom empty VectorXd to Py`. Changing the assertion fixes the test.

