### PR TITLE
Tests: add user-struct test

### DIFF
--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -38,6 +38,7 @@ if(NOT NUMPY_WITH_BROKEN_UFUNC_SUPPORT)
   add_lib_unit_test(user_type)
 endif()
 add_lib_unit_test(std_vector)
+add_lib_unit_test(user_struct)
 
 add_python_unit_test("py-matrix" "unittest/python/test_matrix.py" "unittest")
 
@@ -90,5 +91,9 @@ if(NOT WIN32)
 endif(NOT WIN32)
 
 add_python_unit_test("py-std-vector" "unittest/python/test_std_vector.py"
+                     "python;unittest")
+set_tests_properties("py-std-vector" PROPERTIES DEPENDS ${PYWRAP})
+
+add_python_unit_test("py-user-struct" "unittest/python/test_user_struct.py"
                      "python;unittest")
 set_tests_properties("py-std-vector" PROPERTIES DEPENDS ${PYWRAP})

--- a/unittest/python/test_user_struct.py
+++ b/unittest/python/test_user_struct.py
@@ -1,0 +1,17 @@
+import numpy as np
+from user_struct import *
+
+
+x = np.ones(3)
+y = np.ones(4)
+ms = MyStruct(x, y)
+print(ms.x)
+print(ms.y)
+
+ms.x[0] = 0.0
+
+ms.x = x  # ok
+assert np.allclose(ms.x, x)
+
+ms.y[:] = y
+ms.y = y  # segfault

--- a/unittest/user_struct.cpp
+++ b/unittest/user_struct.cpp
@@ -1,0 +1,23 @@
+#include "eigenpy/eigenpy.hpp"
+
+struct mystruct {
+  Eigen::Vector3d x_;
+  Eigen::Vector4d y_;
+
+  mystruct(const Eigen::Vector3d& x, const Eigen::Vector4d& y) : x_(x), y_(y) {}
+};
+
+BOOST_PYTHON_MODULE(user_struct) {
+  using namespace Eigen;
+  namespace bp = boost::python;
+  eigenpy::enableEigenPy();
+  bp::class_<mystruct>("MyStruct", bp::init<const Vector3d&, const Vector4d&>())
+      .add_property(
+          "x",
+          bp::make_getter(&mystruct::x_, bp::return_internal_reference<>()),
+          bp::make_setter(&mystruct::x_))
+      .add_property(
+          "y",
+          bp::make_getter(&mystruct::y_, bp::return_internal_reference<>()),
+          bp::make_setter(&mystruct::y_));
+}


### PR DESCRIPTION
This PR adds a test wherein a user-defined struct containing fixed-size Eigen members are exposed with getters and setters (similarly to `pinocchio.GeometryObject`'s `meshColor` member).

With the `-mavx2` compile flag, the test succeeds with Boost>=1.77, but fails triggering a segfault on 1.76 and 1.74 (which is required by conda ROS noetic) when assigning to the `Eigen::Vector4d` type member a follows:

```python
ms.y = y
```

However, a slicing-assignment `ms.y[:] = y` does not trigger a segfault.

Assigning to the Vector3d member does not trigger a segfault.  
Without the AVX flag, the test does not fail (so the CI will pass).
 
Compiler: clang++ 15
Environment: conda environment