### PR TITLE
CMake: have python stubs target depend on pywrap target

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -54,7 +54,7 @@ if(GENERATE_PYTHON_STUBS)
   load_stubgen()
 
   generate_stubs(${CMAKE_CURRENT_BINARY_DIR} ${PROJECT_NAME}
-                 ${ABSOLUTE_PYTHON_SITELIB})
+                 ${ABSOLUTE_PYTHON_SITELIB} ${PYWRAP})
 endif(GENERATE_PYTHON_STUBS)
 
 # --- INSTALL SCRIPTS


### PR DESCRIPTION
This PR:
* updates the cmake submodule
* uses the new feature where we can make the Python stubs depend on the Python bindings target