### PR TITLE
WIP: Expose boost::none_t type (and std::nullopt_t when available)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,6 +207,7 @@ set(${PROJECT_NAME}_SOURCES
     src/quaternion.cpp
     src/geometry-conversion.cpp
     src/std-vector.cpp
+    src/optional.cpp
     src/version.cpp)
 
 add_library(${PROJECT_NAME} SHARED ${${PROJECT_NAME}_SOURCES}

--- a/include/eigenpy/optional.hpp
+++ b/include/eigenpy/optional.hpp
@@ -56,6 +56,17 @@ struct nullopt_helper<std::optional> {
 };
 #endif
 
+template<typename NoneType>
+struct NoneToPython {
+  static PyObject *convert(const NoneType&) {
+    Py_RETURN_NONE;
+  }
+
+  static void registration() {
+    bp::to_python_converter<NoneType, NoneToPython, false>();
+  }
+};
+
 template <typename T,
           template <typename> class OptionalTpl = EIGENPY_DEFAULT_OPTIONAL>
 struct OptionalToPython {

--- a/include/eigenpy/optional.hpp
+++ b/include/eigenpy/optional.hpp
@@ -56,11 +56,9 @@ struct nullopt_helper<std::optional> {
 };
 #endif
 
-template<typename NoneType>
+template <typename NoneType>
 struct NoneToPython {
-  static PyObject *convert(const NoneType&) {
-    Py_RETURN_NONE;
-  }
+  static PyObject *convert(const NoneType &) { Py_RETURN_NONE; }
 
   static void registration() {
     bp::to_python_converter<NoneType, NoneToPython, false>();

--- a/src/eigenpy.cpp
+++ b/src/eigenpy.cpp
@@ -22,6 +22,8 @@ void exposeMatrixComplexFloat();
 void exposeMatrixComplexDouble();
 void exposeMatrixComplexLongDouble();
 
+void exposeNoneType();
+
 /* Enable Eigen-Numpy serialization for a set of standard MatrixBase instances.
  */
 void enableEigenPy() {
@@ -54,6 +56,8 @@ void enableEigenPy() {
   exposeMatrixComplexFloat();
   exposeMatrixComplexDouble();
   exposeMatrixComplexLongDouble();
+
+  exposeNoneType();
 }
 
 }  // namespace eigenpy

--- a/src/optional.cpp
+++ b/src/optional.cpp
@@ -9,4 +9,4 @@ void exposeNoneType() {
   detail::NoneToPython<std::nullopt_t>::registration();
 #endif
 }
-} // namespace eigenpy
+}  // namespace eigenpy

--- a/src/optional.cpp
+++ b/src/optional.cpp
@@ -1,0 +1,12 @@
+/// Copyright 2023 CNRS, INRIA
+
+#include "eigenpy/optional.hpp"
+
+namespace eigenpy {
+void exposeNoneType() {
+  detail::NoneToPython<boost::none_t>::registration();
+#ifdef EIGENPY_WITH_CXX17_SUPPORT
+  detail::NoneToPython<std::nullopt_t>::registration();
+#endif
+}
+} // namespace eigenpy

--- a/unittest/bind_optional.cpp.in
+++ b/unittest/bind_optional.cpp.in
@@ -74,6 +74,6 @@ BOOST_PYTHON_MODULE(@MODNAME@) {
           bp::make_setter(&mystruct::msg));
 
   bp::def("none_if_zero", none_if_zero, bp::args("i"));
-  bp::def("create_if_true", create_if_true, bp::args("flag", "b"));
+  bp::def("create_if_true", create_if_true, (bp::arg("flag"), bp::arg("b") = OPT_NONE));
   bp::def("random_mat_if_true", random_mat_if_true, bp::args("flag"));
 }


### PR DESCRIPTION
This PR:

+ adds src/optional.cpp to expose none types
+ this allows to have None as a default arg value for functions (also, shows up in function signatures when stubs are enabled)
+ also allows to have none_t return/argument type