### PR TITLE
CMake: require >= 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (c) 2014-2019 CNRS Copyright (c) 2018-2023 INRIA
 #
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.10)
 
 set(PROJECT_NAME eigenpy)
 set(PROJECT_DESCRIPTION "Bindings between Numpy and Eigen using Boost.Python")


### PR DESCRIPTION
ref. https://github.com/jrl-umi3218/jrl-cmakemodules/issues/338 and fix deprecation warning about CMake 3.5 from CMake 3.27