### PR TITLE
core: fix StdVectorPythonVisitor::expose API

### DIFF
--- a/include/eigenpy/registration_class.hpp
+++ b/include/eigenpy/registration_class.hpp
@@ -30,6 +30,12 @@ class registration_class {
     return *this;
   }
 
+  template <class DerivedVisitor>
+  self& def(bp::def_visitor<DerivedVisitor> const& visitor) {
+    static_cast<DerivedVisitor const&>(visitor).visit(*this);
+    return *this;
+  }
+
   /// \see boost::python::class_::def(char const* name, F f)
   template <class F>
   self& def(char const* name, F f) {

--- a/include/eigenpy/std-vector.hpp
+++ b/include/eigenpy/std-vector.hpp
@@ -67,7 +67,7 @@ struct build_list<vector_type, true> {
   }
 };
 
-/// \brief Change the behaviour of indexing (method __getitem__ in Python).
+/// \brief Change the behavior of indexing (method __getitem__ in Python).
 /// This is suitable for container of Eigen matrix objects if you want to mutate
 /// them.
 template <typename Container>
@@ -418,14 +418,17 @@ struct StdVectorPythonVisitor {
     expose(class_name, doc_string, EmptyPythonVisitor());
   }
 
-  template <typename Visitor>
-  static void expose(const std::string &class_name, const Visitor &visitor) {
+  template <typename DerivedVisitor>
+  static void expose(
+      const std::string &class_name,
+      const boost::python::def_visitor<DerivedVisitor> &visitor) {
     expose(class_name, "", visitor);
   }
 
-  template <typename Visitor>
-  static void expose(const std::string &class_name,
-                     const std::string &doc_string, const Visitor &visitor) {
+  template <typename DerivedVisitor>
+  static void expose(
+      const std::string &class_name, const std::string &doc_string,
+      const boost::python::def_visitor<DerivedVisitor> &visitor) {
     // Apply visitor on already registered type or if type is not already
     // registered, we define and apply the visitor on it
     auto add_std_visitor =

--- a/include/eigenpy/std-vector.hpp
+++ b/include/eigenpy/std-vector.hpp
@@ -419,16 +419,15 @@ struct StdVectorPythonVisitor {
   }
 
   template <typename DerivedVisitor>
-  static void expose(
-      const std::string &class_name,
-      const boost::python::def_visitor<DerivedVisitor> &visitor) {
+  static void expose(const std::string &class_name,
+                     const bp::def_visitor<DerivedVisitor> &visitor) {
     expose(class_name, "", visitor);
   }
 
   template <typename DerivedVisitor>
-  static void expose(
-      const std::string &class_name, const std::string &doc_string,
-      const boost::python::def_visitor<DerivedVisitor> &visitor) {
+  static void expose(const std::string &class_name,
+                     const std::string &doc_string,
+                     const bp::def_visitor<DerivedVisitor> &visitor) {
     // Apply visitor on already registered type or if type is not already
     // registered, we define and apply the visitor on it
     auto add_std_visitor =

--- a/unittest/std_vector.cpp
+++ b/unittest/std_vector.cpp
@@ -30,6 +30,10 @@ void setZero(std::vector<MatType, Eigen::aligned_allocator<MatType> > &Ms) {
   }
 }
 
+struct CustomTestStruct {
+  bool operator==(const CustomTestStruct &) const { return true; }
+};
+
 BOOST_PYTHON_MODULE(std_vector) {
   namespace bp = boost::python;
   using namespace eigenpy;
@@ -58,4 +62,10 @@ BOOST_PYTHON_MODULE(std_vector) {
       .def(boost::python::vector_indexing_suite<
            std::vector<Eigen::Matrix2d> >());
   exposeStdVectorEigenSpecificType<Eigen::Matrix2d>("Mat2d");
+
+  // Test API regression:
+  // Exposing a `std::vector` with documentation doesn't clash with
+  // exposing a `std::vector` with a visitor
+  StdVectorPythonVisitor<std::vector<CustomTestStruct> >::expose(
+      "StdVec_CustomTestStruct", "some documentation");
 }


### PR DESCRIPTION
Avoid overload issue between

```cpp 
static void expose(const std::string &class_name, const std::string &doc_string);
```
 and

```cpp
  static void expose(const std::string &class_name, const Visitor &visitor);
```