### PR TITLE
[unittest] change check for Cpp17 when compiling std::optional test

### DIFF
--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -49,13 +49,16 @@ function(config_bind_optional tagname opttype)
   configure_file(python/test_optional.py.in
                  ${CMAKE_CURRENT_BINARY_DIR}/python/${py_file})
   add_lib_unit_test(${MODNAME})
+  message(STATUS "Adding test for ${opttype}")
   add_python_unit_test("py-optional-${tagname}" "unittest/python/${py_file}"
                        "unittest")
 endfunction()
 
 config_bind_optional(boost "boost::optional")
-if(CMAKE_CXX_STANDARD GREATER 14 AND CMAKE_CXX_STANDARD LESS 98)
+if(cxx_std_17 IN_LIST CMAKE_CXX_COMPILE_FEATURES)
   config_bind_optional(std "std::optional")
+  # request C++17 compiler
+  target_compile_features(bind_optional_std PRIVATE cxx_std_17)
 endif()
 
 add_lib_unit_test(bind_virtual_factory)


### PR DESCRIPTION
This PR:

- switches to checking for the `cxx_std_17` [CMake compile feature](https://cmake.org/cmake/help/latest/manual/cmake-compile-features.7.html) before adding the test for std::optional
- adds said compile feature to the `bind_optional_std` unittest target

This change requires CMake>=3.8.

My reasoning is that previously we checked for `17 <= CMAKE_CXX_STANDARD < 98` which is i) not really semantic ii) error-prone if `CMAKE_CXX_STANDARD` is not set by the user, by the environment variables or by CMake itself.  
In contrast, in the source code, the preprocessor would resolve the `EIGEN_WITH_CXX17_SUPPORT` independently check and compile support for std::optional anyway.