### PR TITLE
Expose std::array types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
-- Support for C++11 `std::array` types
+- Support for C++11 `std::array` types ([#412](https://github.com/stack-of-tasks/pull/412))
 
 ## [3.1.4] - 2023-11-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- Support for C++11 `std::array` types
+
 ## [3.1.4] - 2023-11-27
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,6 +162,7 @@ set(${PROJECT_NAME}_HEADERS
     include/eigenpy/user-type.hpp
     include/eigenpy/ufunc.hpp
     include/eigenpy/register.hpp
+    include/eigenpy/std-array.hpp
     include/eigenpy/std-map.hpp
     include/eigenpy/std-vector.hpp
     include/eigenpy/optional.hpp

--- a/include/eigenpy/std-array.hpp
+++ b/include/eigenpy/std-array.hpp
@@ -81,7 +81,9 @@ class array_indexing_suite
   }
 };
 
-template <typename array_type, bool NoProxy = false>
+template <typename array_type, bool NoProxy = false,
+          class SliceAllocator =
+              std::allocator<typename array_type::value_type> >
 struct StdArrayPythonVisitor {
   typedef typename array_type::value_type value_type;
   /// Fixed size of the array, known at compile time
@@ -107,7 +109,7 @@ struct StdArrayPythonVisitor {
       cl.def(bp::init<const array_type &>(bp::args("self", "other"),
                                           "Copy constructor"));
 
-      array_indexing_suite<array_type, NoProxy> indexing_suite;
+      array_indexing_suite<array_type, NoProxy, SliceAllocator> indexing_suite;
       cl.def(indexing_suite);
     }
   }
@@ -120,8 +122,10 @@ void exposeStdArrayEigenSpecificType(const char *name) {
   oss << "StdArr";
   oss << Size << "_" << name;
   typedef std::array<MatrixType, Size> array_type;
-  StdArrayPythonVisitor<array_type>::expose(
-      oss.str(), details::overload_base_get_item_for_std_vector<array_type>());
+  StdArrayPythonVisitor<array_type, false,
+                        Eigen::aligned_allocator<MatrixType> >::
+      expose(oss.str(),
+             details::overload_base_get_item_for_std_vector<array_type>());
 }
 
 }  // namespace eigenpy

--- a/include/eigenpy/std-array.hpp
+++ b/include/eigenpy/std-array.hpp
@@ -102,7 +102,7 @@ struct StdArrayPythonVisitor {
   template <typename DerivedVisitor>
   static void expose(const std::string &class_name,
                      const std::string &doc_string,
-                     const bp::def_visitor<DerivedVisitor> &) {
+                     const bp::def_visitor<DerivedVisitor> &visitor) {
     if (!register_symbolic_link_to_registered_type<array_type>()) {
       bp::class_<array_type> cl(class_name.c_str(), doc_string.c_str());
       cl.def(bp::init<const array_type &>(bp::args("self", "other"),
@@ -110,6 +110,7 @@ struct StdArrayPythonVisitor {
 
       array_indexing_suite<array_type, NoProxy, SliceAllocator> indexing_suite;
       cl.def(indexing_suite);
+      cl.def(visitor);
     }
   }
 };

--- a/include/eigenpy/std-array.hpp
+++ b/include/eigenpy/std-array.hpp
@@ -80,6 +80,13 @@ class array_indexing_suite
   }
 };
 
+/// \brief Expose an std::array (a C++11 fixed-size array) from a given type
+/// \tparam array_type std::array type to expose
+/// \tparam NoProxy When set to false, the elements will be copied when
+/// returned to Python.
+/// \tparam SliceAllocator Allocator type to use for slices of std::array type
+/// accessed using e.g. __getitem__[0:4] in Python. These slices are returned as
+/// std::vector (dynamic size).
 template <typename array_type, bool NoProxy = false,
           class SliceAllocator =
               std::allocator<typename array_type::value_type> >

--- a/include/eigenpy/std-array.hpp
+++ b/include/eigenpy/std-array.hpp
@@ -40,11 +40,19 @@ class array_indexing_suite
   template <class Class>
   static void extension_def(Class &) {}
 
-  // no-op
-  static void delete_item(Container &, index_type) {}
-  // no-op
-  // no-op
-  static void delete_slice(Container &, index_type, index_type) {}
+  // throws exception
+  static void delete_item(Container &, index_type) {
+    PyErr_SetString(PyExc_NotImplementedError,
+                    "Cannot delete item from std::array type.");
+    bp::throw_error_already_set();
+  }
+
+  // throws exception
+  static void delete_slice(Container &, index_type, index_type) {
+    PyErr_SetString(PyExc_NotImplementedError,
+                    "Cannot delete slice from std::array type.");
+    bp::throw_error_already_set();
+  }
 
   static void set_slice(Container &container, index_type from, index_type to,
                         data_type const &v) {

--- a/include/eigenpy/std-array.hpp
+++ b/include/eigenpy/std-array.hpp
@@ -72,9 +72,8 @@ class array_indexing_suite
   static bp::object get_slice(Container &container, index_type from,
                               index_type to) {
     if (from > to) return bp::object(std::array<data_type, 0>());
-    size_t size = to - from + 1;  // will be >= 0
     slice_vector_type out;
-    for (size_t i = 0; i < size; i++) {
+    for (size_t i = from; i < to; i++) {
       out.push_back(container[i]);
     }
     return bp::object(std::move(out));

--- a/include/eigenpy/std-array.hpp
+++ b/include/eigenpy/std-array.hpp
@@ -40,10 +40,6 @@ class array_indexing_suite
   template <class Class>
   static void extension_def(Class &) {}
 
-  template <class Iter>
-  static void extend(Container &, Iter, Iter) {}
-
-  static void append(Container &, data_type const &) {}
   // no-op
   static void delete_item(Container &, index_type) {}
   // no-op

--- a/include/eigenpy/std-array.hpp
+++ b/include/eigenpy/std-array.hpp
@@ -109,8 +109,10 @@ template <typename array_type, bool NoProxy = false,
               std::allocator<typename array_type::value_type> >
 struct StdArrayPythonVisitor {
   typedef typename array_type::value_type value_type;
-  /// Fixed size of the array, known at compile time
-  static constexpr std::size_t Size = std::tuple_size<array_type>{};
+
+  static ::boost::python::list tolist(array_type &self) {
+    return details::build_list<array_type, NoProxy>::run(self);
+  }
 
   static void expose(const std::string &class_name,
                      const std::string &doc_string = "") {
@@ -133,8 +135,10 @@ struct StdArrayPythonVisitor {
                                           "Copy constructor"));
 
       array_indexing_suite<array_type, NoProxy, SliceAllocator> indexing_suite;
-      cl.def(indexing_suite);
-      cl.def(visitor);
+      cl.def(indexing_suite)
+          .def(visitor)
+          .def("tolist", tolist, bp::arg("self"),
+               "Returns the std::array as a Python list.");
     }
   }
 };

--- a/include/eigenpy/std-array.hpp
+++ b/include/eigenpy/std-array.hpp
@@ -32,6 +32,7 @@ class array_indexing_suite
   typedef typename Container::size_type index_type;
   typedef typename Container::size_type size_type;
   typedef typename Container::difference_type difference_type;
+  static constexpr std::size_t Size = std::tuple_size<Container>{};
 
   template <class Class>
   static void extension_def(Class &) {}
@@ -67,10 +68,12 @@ class array_indexing_suite
 
   static bp::object get_slice(Container &container, index_type from,
                               index_type to) {
-    if (from > to) return bp::object(Container());
-
-    Container out;
-    std::copy(container.begin() + from, container.begin() + to, out.begin());
+    if (from > to) return bp::object(std::array<data_type, 0>());
+    size_t size = to - from + 1;  // will be >= 0
+    std::vector<data_type> out;
+    for (size_t i = 0; i < size; i++) {
+      out.push_back(container[i]);
+    }
     return bp::object(std::move(out));
   }
 };

--- a/include/eigenpy/std-array.hpp
+++ b/include/eigenpy/std-array.hpp
@@ -10,8 +10,7 @@
 
 namespace eigenpy {
 
-template <typename Container, bool NoProxy,
-          class DerivedPolicies>
+template <typename Container, bool NoProxy, class DerivedPolicies>
 class array_indexing_suite;
 namespace details {
 
@@ -45,8 +44,7 @@ class array_indexing_suite
   static void delete_item(Container &, index_type) {}
   // no-op
   // no-op
-  static void delete_slice(Container &, index_type,
-                           index_type) {}
+  static void delete_slice(Container &, index_type, index_type) {}
 
   static void set_slice(Container &container, index_type from, index_type to,
                         data_type const &v) {
@@ -61,11 +59,9 @@ class array_indexing_suite
   static void set_slice(Container &container, index_type from, index_type to,
                         Iter first, Iter last) {
     if (from > to) {
-      // container.insert(container.begin() + from, first, last);
       return;
     } else {
-      // container.erase(container.begin() + from, container.begin() + to);
-      // container.insert(container.begin() + from, first, last);
+      std::copy(first, last, container.begin() + from);
     }
   }
 
@@ -78,7 +74,6 @@ class array_indexing_suite
     return bp::object(std::move(out));
   }
 };
-
 
 template <typename array_type, bool NoProxy = false>
 struct StdArrayPythonVisitor {

--- a/include/eigenpy/std-array.hpp
+++ b/include/eigenpy/std-array.hpp
@@ -1,0 +1,128 @@
+/// Copyright (c) 2023 CNRS INRIA
+
+#ifndef __eigenpy_utils_std_array_hpp__
+#define __eigenpy_utils_std_array_hpp__
+
+#include <boost/python/suite/indexing/indexing_suite.hpp>
+#include "eigenpy/std-vector.hpp"
+
+#include <array>
+
+namespace eigenpy {
+
+template <typename Container, bool NoProxy,
+          class DerivedPolicies>
+class array_indexing_suite;
+namespace details {
+
+template <typename Container, bool NoProxy>
+class final_array_derived_policies
+    : public array_indexing_suite<
+          Container, NoProxy,
+          final_array_derived_policies<Container, NoProxy> > {};
+}  // namespace details
+
+template <typename Container, bool NoProxy = false,
+          class DerivedPolicies =
+              details::final_array_derived_policies<Container, NoProxy> >
+class array_indexing_suite
+    : public bp::vector_indexing_suite<Container, NoProxy, DerivedPolicies> {
+ public:
+  typedef typename Container::value_type data_type;
+  typedef typename Container::value_type key_type;
+  typedef typename Container::size_type index_type;
+  typedef typename Container::size_type size_type;
+  typedef typename Container::difference_type difference_type;
+
+  template <class Class>
+  static void extension_def(Class &) {}
+
+  template <class Iter>
+  static void extend(Container &, Iter, Iter) {}
+
+  static void append(Container &, data_type const &) {}
+  // no-op
+  static void delete_item(Container &, index_type) {}
+  // no-op
+  // no-op
+  static void delete_slice(Container &, index_type,
+                           index_type) {}
+
+  static void set_slice(Container &container, index_type from, index_type to,
+                        data_type const &v) {
+    if (from > to) {
+      return;
+    } else {
+      std::fill(container.begin() + from, container.begin() + to, v);
+    }
+  }
+
+  template <class Iter>
+  static void set_slice(Container &container, index_type from, index_type to,
+                        Iter first, Iter last) {
+    if (from > to) {
+      // container.insert(container.begin() + from, first, last);
+      return;
+    } else {
+      // container.erase(container.begin() + from, container.begin() + to);
+      // container.insert(container.begin() + from, first, last);
+    }
+  }
+
+  static bp::object get_slice(Container &container, index_type from,
+                              index_type to) {
+    if (from > to) return bp::object(Container());
+
+    Container out;
+    std::copy(container.begin() + from, container.begin() + to, out.begin());
+    return bp::object(std::move(out));
+  }
+};
+
+
+template <typename array_type, bool NoProxy = false>
+struct StdArrayPythonVisitor {
+  typedef typename array_type::value_type value_type;
+  /// Fixed size of the array, known at compile time
+  static constexpr std::size_t Size = std::tuple_size<array_type>{};
+
+  static void expose(const std::string &class_name,
+                     const std::string &doc_string = "") {
+    expose(class_name, doc_string, EmptyPythonVisitor());
+  }
+
+  template <typename DerivedVisitor>
+  static void expose(const std::string &class_name,
+                     const bp::def_visitor<DerivedVisitor> &visitor) {
+    expose(class_name, "", visitor);
+  }
+
+  template <typename DerivedVisitor>
+  static void expose(const std::string &class_name,
+                     const std::string &doc_string,
+                     const bp::def_visitor<DerivedVisitor> &) {
+    if (!register_symbolic_link_to_registered_type<array_type>()) {
+      bp::class_<array_type> cl(class_name.c_str(), doc_string.c_str());
+      cl.def(bp::init<const array_type &>(bp::args("self", "other"),
+                                          "Copy constructor"));
+
+      array_indexing_suite<array_type, NoProxy> indexing_suite;
+      cl.def(indexing_suite);
+    }
+  }
+};
+
+/// Exposes std::array<MatrixType, Size>
+template <typename MatrixType, std::size_t Size>
+void exposeStdArrayEigenSpecificType(const char *name) {
+  std::ostringstream oss;
+  oss << "StdArr";
+  oss << Size << "_" << name;
+  typedef std::array<MatrixType, Size> array_type;
+  StdArrayPythonVisitor<array_type>::expose(
+      oss.str(), details::overload_base_get_item_for_std_vector<array_type>());
+}
+
+}  // namespace eigenpy
+
+#endif  // ifndef __eigenpy_utils_std_array_hpp__

--- a/include/eigenpy/std-vector.hpp
+++ b/include/eigenpy/std-vector.hpp
@@ -234,6 +234,20 @@ struct reference_arg_from_python<std::vector<Type, Allocator> &>
 
 namespace eigenpy {
 
+namespace details {
+/// Defines traits for the container, used in \struct StdContainerFromPythonList
+template <class Container>
+struct container_traits {
+  // default behavior expects allocators
+  typedef typename Container::allocator_type Allocator;
+};
+
+template <typename _Tp, std::size_t Size>
+struct container_traits<std::array<_Tp, Size> > {
+  typedef void Allocator;
+};
+};  // namespace details
+
 ///
 /// \brief Register the conversion from a Python list to a std::vector
 ///
@@ -242,6 +256,7 @@ namespace eigenpy {
 template <typename vector_type, bool NoProxy>
 struct StdContainerFromPythonList {
   typedef typename vector_type::value_type T;
+  typedef typename details::container_traits<vector_type>::Allocator Allocator;
 
   /// \brief Check if obj_ptr can be converted
   static void *convertible(PyObject *obj_ptr) {

--- a/include/eigenpy/std-vector.hpp
+++ b/include/eigenpy/std-vector.hpp
@@ -242,7 +242,6 @@ namespace eigenpy {
 template <typename vector_type, bool NoProxy>
 struct StdContainerFromPythonList {
   typedef typename vector_type::value_type T;
-  typedef typename vector_type::allocator_type Allocator;
 
   /// \brief Check if obj_ptr can be converted
   static void *convertible(PyObject *obj_ptr) {

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -38,6 +38,7 @@ if(NOT NUMPY_WITH_BROKEN_UFUNC_SUPPORT)
   add_lib_unit_test(user_type)
 endif()
 add_lib_unit_test(std_vector)
+add_lib_unit_test(std_array)
 add_lib_unit_test(user_struct)
 
 function(config_bind_optional tagname opttype)
@@ -109,6 +110,10 @@ endif(NOT WIN32)
 add_python_unit_test("py-std-vector" "unittest/python/test_std_vector.py"
                      "python;unittest")
 set_tests_properties("py-std-vector" PROPERTIES DEPENDS ${PYWRAP})
+
+add_python_unit_test("py-std-array" "unittest/python/test_std_array.py"
+                     "python;unittest")
+set_tests_properties("py-std-array" PROPERTIES DEPENDS ${PYWRAP})
 
 add_python_unit_test("py-user-struct" "unittest/python/test_user_struct.py"
                      "python;unittest")

--- a/unittest/python/test_std_array.py
+++ b/unittest/python/test_std_array.py
@@ -5,6 +5,12 @@ ints = std_array.get_arr_3_ints()
 print(ints[0])
 print(ints[1])
 print(ints[2])
+
+_ints_slice = ints[1:2]
+assert len(_ints_slice) == 2, "Slice size should be 2, got %d" % len(_ints_slice)
+assert _ints_slice[0] == 1
+assert _ints_slice[1] == 2
+
 print(ints.tolist())
 
 vecs = std_array.get_arr_3_vecs()

--- a/unittest/python/test_std_array.py
+++ b/unittest/python/test_std_array.py
@@ -6,14 +6,30 @@ print(ints[0])
 print(ints[1])
 print(ints[2])
 
-_ints_slice = ints[1:2]
-assert len(_ints_slice) == 2, "Slice size should be 2, got %d" % len(_ints_slice)
-assert _ints_slice[0] == 1
-assert _ints_slice[1] == 2
+_ints_slice = ints[1:3]
+print("Printing slice...")
+for el in _ints_slice:
+    print(el)
 
-print(ints.tolist())
+ref = [1, 2, 3]
+assert len(ref[1:2]) == 1  # sanity check
+
+assert len(_ints_slice) == 2, "Slice size should be 1, got %d" % len(_ints_slice)
+assert _ints_slice[0] == 2
+assert _ints_slice[1] == 3
+
+# print(ints.tolist())
 
 vecs = std_array.get_arr_3_vecs()
-print(vecs[0])
-print(vecs[1])
-print(vecs[2])
+assert len(vecs) == 3
+# print(vecs[0])
+# print(vecs[1])
+# print(vecs[2])
+
+## Tests for the full-size slice
+
+v2 = vecs[:]
+assert isinstance(v2, std_array.StdVec_VectorXd)
+assert len(v2) == 3
+print(v2.tolist())
+print(v2[0])

--- a/unittest/python/test_std_array.py
+++ b/unittest/python/test_std_array.py
@@ -5,6 +5,8 @@ ints = std_array.get_arr_3_ints()
 print(ints[0])
 print(ints[1])
 print(ints[2])
+print(ints.tolist())
+assert ints.tolist() == [1, 2, 3]
 
 _ints_slice = ints[1:3]
 print("Printing slice...")

--- a/unittest/python/test_std_array.py
+++ b/unittest/python/test_std_array.py
@@ -41,6 +41,11 @@ print(ts.integs[:].tolist())
 print(ts.vecs[0])
 print(ts.vecs[1])
 
+ts.integs[:] = 111
+print("Test of set_slice for std::array<int>:", ts.integs[:].tolist())
+for el in ts.integs:
+    assert el == 111
+
 ts.vecs[0][0] = 0.0
 ts.vecs[1][0] = -243
 print(ts.vecs[0])

--- a/unittest/python/test_std_array.py
+++ b/unittest/python/test_std_array.py
@@ -18,6 +18,95 @@ assert len(_ints_slice) == 2, "Slice size should be 1, got %d" % len(_ints_slice
 assert _ints_slice[0] == 2
 assert _ints_slice[1] == 3
 
+# Test that insert/delete is impossible with the slice operator
+
+# prepend
+try:
+    ints[0:0] = [0, 1]
+except NotImplementedError:
+    pass
+else:
+    assert False, "Insert value with slice operator should be impossible"
+
+# append
+try:
+    ints[10:12] = [0]
+except NotImplementedError:
+    pass
+else:
+    assert False, "Insert value with slice operator should be impossible"
+
+# append
+try:
+    ints[3:3] = [0]
+except NotImplementedError:
+    pass
+else:
+    assert False, "Insert value with slice operator should be impossible"
+
+# Erase two elements and replace by one
+try:
+    ints[1:3] = [0]
+except NotImplementedError:
+    pass
+else:
+    assert False, "Insert value with slice operator should be impossible"
+
+# Erase two elements and replace by three
+try:
+    ints[1:3] = [0, 1, 2]
+except NotImplementedError:
+    pass
+else:
+    assert False, "Insert value with slice operator should be impossible"
+
+# Test that delete operator is not implemented
+# Index delete
+try:
+    del ints[0]
+except NotImplementedError:
+    pass
+else:
+    assert False, "del is not implemented"
+
+# Slice delete
+try:
+    del ints[1:3]
+except NotImplementedError:
+    pass
+else:
+    assert False, "del is not implemented"
+
+# Slice delete
+try:
+    del ints[1:3]
+except NotImplementedError:
+    pass
+else:
+    assert False, "del is not implemented"
+
+# Test that append/extend are not implemented
+# append
+try:
+    ints.append(4)
+except AttributeError:
+    pass
+else:
+    assert False, "append is not implemented"
+
+# extend
+try:
+    ints.extend([4, 5])
+except AttributeError:
+    pass
+else:
+    assert False, "extend is not implemented"
+
+# Test set_slice nominal case
+ints[1:3] = [10, 20]
+assert ints[1] == 10
+assert ints[2] == 20
+
 # print(ints.tolist())
 
 vecs = std_array.get_arr_3_vecs()

--- a/unittest/python/test_std_array.py
+++ b/unittest/python/test_std_array.py
@@ -22,14 +22,14 @@ assert _ints_slice[1] == 3
 
 vecs = std_array.get_arr_3_vecs()
 assert len(vecs) == 3
-# print(vecs[0])
-# print(vecs[1])
-# print(vecs[2])
+print(vecs[0])
+print(vecs[1])
+print(vecs[2])
 
-## Tests for the full-size slice
+# slices do not work for Eigen objects...
 
-v2 = vecs[:]
-assert isinstance(v2, std_array.StdVec_VectorXd)
-assert len(v2) == 3
-print(v2.tolist())
-print(v2[0])
+# v2 = vecs[:]
+# assert isinstance(v2, std_array.StdVec_VectorXd)
+# assert len(v2) == 3
+# print(v2.tolist())
+# print(v2[0])

--- a/unittest/python/test_std_array.py
+++ b/unittest/python/test_std_array.py
@@ -41,7 +41,7 @@ print(ts.integs[:].tolist())
 print(ts.vecs[0])
 print(ts.vecs[1])
 
-ts.vecs[0][0] = 0.
+ts.vecs[0][0] = 0.0
 ts.vecs[1][0] = -243
 print(ts.vecs[0])
 print(ts.vecs[1])

--- a/unittest/python/test_std_array.py
+++ b/unittest/python/test_std_array.py
@@ -33,3 +33,15 @@ print(vecs[2])
 # assert len(v2) == 3
 # print(v2.tolist())
 # print(v2[0])
+
+ts = std_array.test_struct()
+assert len(ts.integs) == 3
+assert len(ts.vecs) == 2
+print(ts.integs[:].tolist())
+print(ts.vecs[0])
+print(ts.vecs[1])
+
+ts.vecs[0][0] = 0.
+ts.vecs[1][0] = -243
+print(ts.vecs[0])
+print(ts.vecs[1])

--- a/unittest/python/test_std_array.py
+++ b/unittest/python/test_std_array.py
@@ -1,0 +1,13 @@
+import std_array
+
+
+ints = std_array.get_arr_3_ints()
+print(ints[0])
+print(ints[1])
+print(ints[2])
+print(ints.tolist())
+
+vecs = std_array.get_arr_3_vecs()
+print(vecs[0])
+print(vecs[1])
+print(vecs[2])

--- a/unittest/std_array.cpp
+++ b/unittest/std_array.cpp
@@ -15,6 +15,17 @@ std::array<VectorXd, 3> get_arr_3_vecs() {
   return out;
 }
 
+struct test_struct {
+  std::array<int, 3> integs;
+  std::array<VectorXd, 2> vecs;
+  test_struct() {
+    integs = {42, 3, -1};
+    vecs[0].setRandom(4);  // 4 randoms between [-1,1]
+    vecs[1].setZero(11);  // 11 zeroes
+  }
+};
+
+
 BOOST_PYTHON_MODULE(std_array) {
   using namespace eigenpy;
 
@@ -23,9 +34,14 @@ BOOST_PYTHON_MODULE(std_array) {
   StdArrayPythonVisitor<std::array<int, 3> >::expose("StdArr3_int");
   StdVectorPythonVisitor<std::vector<int>, true>::expose("StdVec_int");
 
+  exposeStdArrayEigenSpecificType<VectorXd, 2>("VectorXd");
   exposeStdArrayEigenSpecificType<VectorXd, 3>("VectorXd");
   exposeStdVectorEigenSpecificType<VectorXd>("VectorXd");
 
   bp::def("get_arr_3_ints", get_arr_3_ints);
   bp::def("get_arr_3_vecs", get_arr_3_vecs);
+
+  bp::class_<test_struct>("test_struct", bp::init<>(bp::args("self")))
+    .def_readwrite("integs", &test_struct::integs)
+    .def_readwrite("vecs", &test_struct::vecs);
 }

--- a/unittest/std_array.cpp
+++ b/unittest/std_array.cpp
@@ -22,7 +22,9 @@ BOOST_PYTHON_MODULE(std_array) {
 
   StdArrayPythonVisitor<std::array<int, 3> >::expose("StdArr3_int");
   StdVectorPythonVisitor<std::vector<int>, true>::expose("StdVec_int");
+
   exposeStdArrayEigenSpecificType<VectorXd, 3>("VectorXd");
+  exposeStdVectorEigenSpecificType<VectorXd>("VectorXd");
 
   bp::def("get_arr_3_ints", get_arr_3_ints);
   bp::def("get_arr_3_vecs", get_arr_3_vecs);

--- a/unittest/std_array.cpp
+++ b/unittest/std_array.cpp
@@ -21,6 +21,7 @@ BOOST_PYTHON_MODULE(std_array) {
   enableEigenPy();
 
   StdArrayPythonVisitor<std::array<int, 3> >::expose("StdArr3_int");
+  StdVectorPythonVisitor<std::vector<int>, true>::expose("StdVec_int");
   exposeStdArrayEigenSpecificType<VectorXd, 3>("VectorXd");
 
   bp::def("get_arr_3_ints", get_arr_3_ints);

--- a/unittest/std_array.cpp
+++ b/unittest/std_array.cpp
@@ -21,10 +21,9 @@ struct test_struct {
   test_struct() {
     integs = {42, 3, -1};
     vecs[0].setRandom(4);  // 4 randoms between [-1,1]
-    vecs[1].setZero(11);  // 11 zeroes
+    vecs[1].setZero(11);   // 11 zeroes
   }
 };
-
 
 BOOST_PYTHON_MODULE(std_array) {
   using namespace eigenpy;
@@ -42,6 +41,6 @@ BOOST_PYTHON_MODULE(std_array) {
   bp::def("get_arr_3_vecs", get_arr_3_vecs);
 
   bp::class_<test_struct>("test_struct", bp::init<>(bp::args("self")))
-    .def_readwrite("integs", &test_struct::integs)
-    .def_readwrite("vecs", &test_struct::vecs);
+      .def_readwrite("integs", &test_struct::integs)
+      .def_readwrite("vecs", &test_struct::vecs);
 }

--- a/unittest/std_array.cpp
+++ b/unittest/std_array.cpp
@@ -1,0 +1,28 @@
+/// @file
+/// @copyright Copyright 2023 CNRS INRIA
+
+#include "eigenpy/std-array.hpp"
+
+using Eigen::VectorXd;
+
+std::array<int, 3> get_arr_3_ints() { return {1, 2, 3}; }
+
+std::array<VectorXd, 3> get_arr_3_vecs() {
+  std::array<VectorXd, 3> out;
+  out[0].setOnes(4);
+  out[1].setZero(2);
+  out[2].setRandom(10);
+  return out;
+}
+
+BOOST_PYTHON_MODULE(std_array) {
+  using namespace eigenpy;
+
+  enableEigenPy();
+
+  StdArrayPythonVisitor<std::array<int, 3> >::expose("StdArr3_int");
+  exposeStdArrayEigenSpecificType<VectorXd, 3>("VectorXd");
+
+  bp::def("get_arr_3_ints", get_arr_3_ints);
+  bp::def("get_arr_3_vecs", get_arr_3_vecs);
+}

--- a/unittest/std_array.cpp
+++ b/unittest/std_array.cpp
@@ -30,7 +30,7 @@ BOOST_PYTHON_MODULE(std_array) {
 
   enableEigenPy();
 
-  StdArrayPythonVisitor<std::array<int, 3> >::expose("StdArr3_int");
+  StdArrayPythonVisitor<std::array<int, 3>, true>::expose("StdArr3_int");
   StdVectorPythonVisitor<std::vector<int>, true>::expose("StdVec_int");
 
   exposeStdArrayEigenSpecificType<VectorXd, 2>("VectorXd");


### PR DESCRIPTION
**Remarks**

Slices (i.e. using `object[a:b]` in Python on a subscriptable object) of `std::array<Eigen::Matrix, K>` types do not work. They do work for other types - this comes from exposing the Eigen std::array types with `eigenpy::details::overload_base_item_for...` which redefines `::base_get_item` for the underlying indexing_suite visitor that is used.

I think they might not work for slices of `std::vector<Eigen::Matrix>` types either, no @jorisv ?

**Meta**

Resolves #411 