### PR TITLE
Fix EigenToPy/EigenFromPy on Windows

### DIFF
--- a/.github/workflows/macos-linux-conda.yml
+++ b/.github/workflows/macos-linux-conda.yml
@@ -102,7 +102,7 @@ jobs:
           -DGENERATE_PYTHON_STUBS=ON \
           -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
           -DCMAKE_CXX_FLAGS=${{ matrix.cxx_options }}
-        cmake --build . -j4
+        cmake --build . -j3
         ctest --output-on-failure
         cmake --install .
 

--- a/.github/workflows/windows-conda.yml
+++ b/.github/workflows/windows-conda.yml
@@ -79,7 +79,7 @@ jobs:
         if errorlevel 1 exit 1
 
         :: Build
-        cmake --build . -j4
+        cmake --build . -j3
         if errorlevel 1 exit 1
 
         :: Testing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Allow EigenToPy/EigenFromPy specialization with CL compiler ([#462](https://github.com/stack-of-tasks/eigenpy/pull/462))
+
 ## [3.5.0] - 2024-04-14
 
 ### Added

--- a/include/eigenpy/eigen-from-python.hpp
+++ b/include/eigenpy/eigen-from-python.hpp
@@ -290,16 +290,10 @@ struct eigen_from_py_impl<MatType, Eigen::MatrixBase<MatType> > {
   static void registration();
 };
 
-#ifdef EIGENPY_MSVC_COMPILER
-template <typename EigenType>
-struct EigenFromPy<EigenType,
-                   typename boost::remove_reference<EigenType>::type::Scalar>
-#else
-template <typename EigenType, typename _Scalar>
-struct EigenFromPy
-#endif
-    : eigen_from_py_impl<EigenType> {
-};
+template <typename EigenType,
+          typename Scalar =
+              typename boost::remove_reference<EigenType>::type::Scalar>
+struct EigenFromPy : eigen_from_py_impl<EigenType> {};
 
 template <typename MatType>
 void *eigen_from_py_impl<MatType, Eigen::MatrixBase<MatType> >::convertible(

--- a/include/eigenpy/eigen-to-python.hpp
+++ b/include/eigenpy/eigen-to-python.hpp
@@ -16,51 +16,6 @@
 #include "eigenpy/scipy-type.hpp"
 #include "eigenpy/registration.hpp"
 
-namespace boost {
-namespace python {
-
-template <typename MatrixRef, class MakeHolder>
-struct to_python_indirect_eigen {
-  template <class U>
-  inline PyObject* operator()(U const& mat) const {
-    return eigenpy::EigenToPy<MatrixRef>::convert(const_cast<U&>(mat));
-  }
-
-#ifndef BOOST_PYTHON_NO_PY_SIGNATURES
-  inline PyTypeObject const* get_pytype() const {
-    return converter::registered_pytype<MatrixRef>::get_pytype();
-  }
-#endif
-};
-
-template <typename Scalar, int RowsAtCompileTime, int ColsAtCompileTime,
-          int Options, int MaxRowsAtCompileTime, int MaxColsAtCompileTime,
-          class MakeHolder>
-struct to_python_indirect<
-    Eigen::Matrix<Scalar, RowsAtCompileTime, ColsAtCompileTime, Options,
-                  MaxRowsAtCompileTime, MaxColsAtCompileTime>&,
-    MakeHolder>
-    : to_python_indirect_eigen<
-          Eigen::Matrix<Scalar, RowsAtCompileTime, ColsAtCompileTime, Options,
-                        MaxRowsAtCompileTime, MaxColsAtCompileTime>&,
-          MakeHolder> {};
-
-template <typename Scalar, int RowsAtCompileTime, int ColsAtCompileTime,
-          int Options, int MaxRowsAtCompileTime, int MaxColsAtCompileTime,
-          class MakeHolder>
-struct to_python_indirect<
-    const Eigen::Matrix<Scalar, RowsAtCompileTime, ColsAtCompileTime, Options,
-                        MaxRowsAtCompileTime, MaxColsAtCompileTime>&,
-    MakeHolder>
-    : to_python_indirect_eigen<
-          const Eigen::Matrix<Scalar, RowsAtCompileTime, ColsAtCompileTime,
-                              Options, MaxRowsAtCompileTime,
-                              MaxColsAtCompileTime>&,
-          MakeHolder> {};
-
-}  // namespace python
-}  // namespace boost
-
 namespace eigenpy {
 
 EIGENPY_DOCUMENTATION_START_IGNORE
@@ -202,16 +157,10 @@ struct eigen_to_py_impl_tensor {
 
 EIGENPY_DOCUMENTATION_END_IGNORE
 
-#ifdef EIGENPY_MSVC_COMPILER
-template <typename EigenType>
-struct EigenToPy<EigenType,
-                 typename boost::remove_reference<EigenType>::type::Scalar>
-#else
-template <typename EigenType, typename _Scalar>
-struct EigenToPy
-#endif
-    : eigen_to_py_impl<EigenType> {
-};
+template <typename EigenType,
+          typename Scalar =
+              typename boost::remove_reference<EigenType>::type::Scalar>
+struct EigenToPy : eigen_to_py_impl<EigenType> {};
 
 template <typename MatType>
 struct EigenToPyConverter {
@@ -219,6 +168,52 @@ struct EigenToPyConverter {
     bp::to_python_converter<MatType, EigenToPy<MatType>, true>();
   }
 };
+
 }  // namespace eigenpy
+
+namespace boost {
+namespace python {
+
+template <typename MatrixRef, class MakeHolder>
+struct to_python_indirect_eigen {
+  template <class U>
+  inline PyObject* operator()(U const& mat) const {
+    return eigenpy::EigenToPy<MatrixRef>::convert(const_cast<U&>(mat));
+  }
+
+#ifndef BOOST_PYTHON_NO_PY_SIGNATURES
+  inline PyTypeObject const* get_pytype() const {
+    return converter::registered_pytype<MatrixRef>::get_pytype();
+  }
+#endif
+};
+
+template <typename Scalar, int RowsAtCompileTime, int ColsAtCompileTime,
+          int Options, int MaxRowsAtCompileTime, int MaxColsAtCompileTime,
+          class MakeHolder>
+struct to_python_indirect<
+    Eigen::Matrix<Scalar, RowsAtCompileTime, ColsAtCompileTime, Options,
+                  MaxRowsAtCompileTime, MaxColsAtCompileTime>&,
+    MakeHolder>
+    : to_python_indirect_eigen<
+          Eigen::Matrix<Scalar, RowsAtCompileTime, ColsAtCompileTime, Options,
+                        MaxRowsAtCompileTime, MaxColsAtCompileTime>&,
+          MakeHolder> {};
+
+template <typename Scalar, int RowsAtCompileTime, int ColsAtCompileTime,
+          int Options, int MaxRowsAtCompileTime, int MaxColsAtCompileTime,
+          class MakeHolder>
+struct to_python_indirect<
+    const Eigen::Matrix<Scalar, RowsAtCompileTime, ColsAtCompileTime, Options,
+                        MaxRowsAtCompileTime, MaxColsAtCompileTime>&,
+    MakeHolder>
+    : to_python_indirect_eigen<
+          const Eigen::Matrix<Scalar, RowsAtCompileTime, ColsAtCompileTime,
+                              Options, MaxRowsAtCompileTime,
+                              MaxColsAtCompileTime>&,
+          MakeHolder> {};
+
+}  // namespace python
+}  // namespace boost
 
 #endif  // __eigenpy_eigen_to_python_hpp__

--- a/include/eigenpy/fwd.hpp
+++ b/include/eigenpy/fwd.hpp
@@ -125,13 +125,13 @@ namespace bp = boost::python;
 #endif
 
 namespace eigenpy {
-template <typename MatType,
-          typename Scalar =
-              typename boost::remove_reference<MatType>::type::Scalar>
+
+// Default Scalar value can't be defined in the declaration
+// because of a CL bug.
+// See https://github.com/stack-of-tasks/eigenpy/pull/462
+template <typename MatType, typename Scalar>
 struct EigenToPy;
-template <typename MatType,
-          typename Scalar =
-              typename boost::remove_reference<MatType>::type::Scalar>
+template <typename MatType, typename Scalar>
 struct EigenFromPy;
 
 template <typename T>

--- a/include/eigenpy/register.hpp
+++ b/include/eigenpy/register.hpp
@@ -106,7 +106,7 @@ struct EIGENPY_DLLAPI Register {
   static Register &instance();
 
  private:
-  Register(){};
+  Register() {};
 
   struct Compare_PyTypeObject {
     bool operator()(const PyTypeObject *a, const PyTypeObject *b) const {


### PR DESCRIPTION
On Windows EigenToPy/EigenFromPy are not defined (only specialized) to avoid a CL compiler issue.

If we make the following declaration:

```cpp
template <typename MatType,
          typename Scalar =
              typename boost::remove_reference<MatType>::type::Scalar>
struct EigenToPy;
```

CL complain that MatType is an undeclared identifier.

To avoid that, a first hack was to not define but only specialize EigenToPy (same for EigenFromPy) on Windows:

```cpp
template <typename EigenType>
struct EigenToPy<EigenType,
                 typename boost::remove_reference<EigenType>::type::Scalar>
    : eigen_to_py_impl<EigenType> {
};
```

Unfortunately, this hack prevent to specialize EigenToPy for custom scalar type with CL.

This PR revert this hack and fix the first issue by moving the default Scalar definition in the EigenToPy definition.