### PR TITLE
Add unit test multiple_registration, fix register_symbolic_link_to_registered_type() for multiple successive registrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Added a deprecation call policy shortcut ([#466](https://github.com/stack-of-tasks/eigenpy/pull/466))
 
+### Fixed
+- Fix register_symbolic_link_to_registered_type() for multiple successive registrations ([#](https://github.com/stack-of-tasks/eigenpy/pull/471))
+
 ## [3.5.1] - 2024-04-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added a deprecation call policy shortcut ([#466](https://github.com/stack-of-tasks/eigenpy/pull/466))
 
 ### Fixed
-- Fix register_symbolic_link_to_registered_type() for multiple successive registrations ([#](https://github.com/stack-of-tasks/eigenpy/pull/471))
+- Fix register_symbolic_link_to_registered_type() for multiple successive registrations ([#471](https://github.com/stack-of-tasks/eigenpy/pull/471))
 
 ## [3.5.1] - 2024-04-25
 

--- a/include/eigenpy/registration.hpp
+++ b/include/eigenpy/registration.hpp
@@ -45,6 +45,7 @@ inline bool register_symbolic_link_to_registered_type() {
     const bp::converter::registration* reg =
         bp::converter::registry::query(info);
     bp::handle<> class_obj(reg->get_class_object());
+    bp::incref(class_obj.get());
     bp::scope().attr(reg->get_class_object()->tp_name) = bp::object(class_obj);
     return true;
   }
@@ -61,6 +62,7 @@ inline bool register_symbolic_link_to_registered_type(const Visitor& visitor) {
     const bp::converter::registration* reg =
         bp::converter::registry::query(info);
     bp::handle<> class_obj(reg->get_class_object());
+    bp::incref(class_obj.get());
     bp::object object(class_obj);
     bp::scope().attr(reg->get_class_object()->tp_name) = object;
     registration_class<T> cl(object);

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -30,6 +30,7 @@ endmacro(ADD_LIB_UNIT_TEST)
 
 add_dependencies(build_tests ${PYWRAP})
 add_lib_unit_test(matrix)
+add_lib_unit_test(multiple_registration)
 if(BUILD_TESTING_SCIPY)
   find_scipy()
   add_lib_unit_test(sparse_matrix)
@@ -101,6 +102,8 @@ endif()
 add_lib_unit_test(bind_virtual_factory)
 
 add_python_lib_unit_test("py-matrix" "unittest/python/test_matrix.py")
+add_python_lib_unit_test("py-multiple-registration"
+                         "unittest/python/test_multiple_registration.py")
 
 add_python_lib_unit_test("py-tensor" "unittest/python/test_tensor.py")
 add_python_lib_unit_test("py-geometry" "unittest/python/test_geometry.py")

--- a/unittest/multiple_registration.cpp
+++ b/unittest/multiple_registration.cpp
@@ -1,0 +1,28 @@
+#include "eigenpy/registration.hpp"
+#include <cstdio>
+
+namespace bp = boost::python;
+
+class X {
+ public:
+  X() {}
+  void operator()() { printf("DOOT\n"); }
+};
+
+class X_wrapper : public X, bp::wrapper<X> {
+ public:
+  static void expose() {
+    if (!eigenpy::register_symbolic_link_to_registered_type<X>()) {
+      bp::class_<X>("X", bp::init<>()).def("__call__", &X::operator());
+    }
+  }
+};
+
+BOOST_PYTHON_MODULE(multiple_registration) {
+  X_wrapper::expose();
+  X_wrapper::expose();
+  X_wrapper::expose();
+  X_wrapper::expose();
+  X_wrapper::expose();
+  X_wrapper::expose();
+}

--- a/unittest/python/test_multiple_registration.py
+++ b/unittest/python/test_multiple_registration.py
@@ -1,0 +1,1 @@
+import multiple_registration  # noqa


### PR DESCRIPTION
+ added a unit test where I expose the same class multiple times with the `register_symbolic_link_to_registered_type()` safeguard, it currently produces a wonderful 36 errors :D
+ add a missing incref in `register_symbolic_link_to_registered_type()` (thanks @jcarpent)

Here's the valgrind report without the fix:
[report.log](https://github.com/stack-of-tasks/eigenpy/files/15406791/report.log)
