### PR TITLE
Fix ROS CI & compilation

### DIFF
--- a/.github/workflows/ros_ci.yml
+++ b/.github/workflows/ros_ci.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           submodules: recursive
       # Run industrial_ci
-      - uses: 'ros-industrial/industrial_ci@875c2ae'
+      - uses: 'ros-industrial/industrial_ci@875c2aebfd634eebaa84dbe5198f2fdb4c5f1b7e'
         env: ${{ matrix.env }}
 
   check:

--- a/.github/workflows/ros_ci.yml
+++ b/.github/workflows/ros_ci.yml
@@ -32,26 +32,23 @@ jobs:
     strategy:
       matrix:
         env:
+          # ROS1
           - {ROS_DISTRO: noetic}
+          # ROS2
           - {ROS_DISTRO: iron}
           - {ROS_DISTRO: humble}
+          - {ROS_DISTRO: jazzy}
           - {ROS_DISTRO: rolling}
     env:
-      # CCACHE_DIR: /home/runner/.ccache # Enable ccache
-      PRERELEASE: true
+      # PRERELEASE: true  # Fails due to issues in the underlying Docker image
       BUILDER: colcon
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
-      # This step will fetch/store the directory used by ccache before/after the ci run
-      # - uses: actions/cache@v3
-      #   with:
-      #     path: ${{ env.CCACHE_DIR }}
-      #     key: ccache-${{ matrix.env.ROS_DISTRO }}-${{ matrix.env.ROS_REPO }}
       # Run industrial_ci
-      - uses: 'ros-industrial/industrial_ci@9f963f67ebb889792175776c5ee00134d7bb569b'
+      - uses: 'ros-industrial/industrial_ci@875c2ae'
         env: ${{ matrix.env }}
 
   check:

--- a/package.xml
+++ b/package.xml
@@ -20,7 +20,9 @@
   <depend condition="$ROS_PYTHON_VERSION == 2">python</depend>
   <depend condition="$ROS_PYTHON_VERSION == 3">python3</depend>
   <depend condition="$ROS_PYTHON_VERSION == 2">python-numpy</depend>
+  <depend condition="$ROS_PYTHON_VERSION == 2">python-scipy</depend>
   <depend condition="$ROS_PYTHON_VERSION == 3">python3-numpy</depend>
+  <depend condition="$ROS_PYTHON_VERSION == 3">python3-scipy</depend>
   <depend>eigen</depend>
   <depend>boost</depend>
 


### PR DESCRIPTION
Requires re-enabling the workflow. Should fix the broken buildfarm builds.