### PR TITLE
Fix warnings to address unstable build on buildfarm

### DIFF
--- a/include/eigenpy/deprecation-policy.hpp
+++ b/include/eigenpy/deprecation-policy.hpp
@@ -19,6 +19,8 @@ constexpr PyObject *deprecationTypeToPyObj(DeprecationType dep) {
       return PyExc_DeprecationWarning;
     case DeprecationType::FUTURE:
       return PyExc_FutureWarning;
+    default:  // The switch handles all cases explicitly, this should never be triggered.
+      throw std::invalid_argument("Undefined DeprecationType - this should never be triggered.");
   }
 }
 

--- a/include/eigenpy/deprecation-policy.hpp
+++ b/include/eigenpy/deprecation-policy.hpp
@@ -19,8 +19,10 @@ constexpr PyObject *deprecationTypeToPyObj(DeprecationType dep) {
       return PyExc_DeprecationWarning;
     case DeprecationType::FUTURE:
       return PyExc_FutureWarning;
-    default:  // The switch handles all cases explicitly, this should never be triggered.
-      throw std::invalid_argument("Undefined DeprecationType - this should never be triggered.");
+    default:  // The switch handles all cases explicitly, this should never be
+              // triggered.
+      throw std::invalid_argument(
+          "Undefined DeprecationType - this should never be triggered.");
   }
 }
 

--- a/unittest/bind_virtual_factory.cpp
+++ b/unittest/bind_virtual_factory.cpp
@@ -73,7 +73,7 @@ struct VirtualClassWrapper : MyVirtualClass, bp::wrapper<MyVirtualClass> {
 
   shared_ptr<MyVirtualData> createData() const override {
     if (bp::override fo = this->get_override("createData")) {
-      bp::object result = fo();
+      bp::object result = fo().as<bp::object>();
       return bp::extract<shared_ptr<MyVirtualData> >(result);
     }
     return default_createData();

--- a/unittest/bind_virtual_factory.cpp
+++ b/unittest/bind_virtual_factory.cpp
@@ -74,7 +74,7 @@ struct VirtualClassWrapper : MyVirtualClass, bp::wrapper<MyVirtualClass> {
   shared_ptr<MyVirtualData> createData() const override {
     if (bp::override fo = this->get_override("createData")) {
       bp::object result = fo();
-      return bp::extract<shared_ptr<MyVirtualData>>(result);
+      return bp::extract<shared_ptr<MyVirtualData> >(result);
     }
     return default_createData();
   }

--- a/unittest/bind_virtual_factory.cpp
+++ b/unittest/bind_virtual_factory.cpp
@@ -72,7 +72,10 @@ struct VirtualClassWrapper : MyVirtualClass, bp::wrapper<MyVirtualClass> {
   }
 
   shared_ptr<MyVirtualData> createData() const override {
-    if (bp::override fo = this->get_override("createData")) return fo();
+    if (bp::override fo = this->get_override("createData")) {
+      bp::object result = fo();
+      return bp::extract<shared_ptr<MyVirtualData>>(result);
+    }
     return default_createData();
   }
 


### PR DESCRIPTION
I'm having issues with the new pre-commit config (it fails on MacOS Python2 venv config - on Linux) so formatting may not be applied yet. Hoping for pre-commit CI to correct me :-)