### PR TITLE
Fix error: redefinition of ‘struct eigenpy::NumpyEquivalentType<...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Remove CMake CMP0167 warnings ([#487](https://github.com/stack-of-tasks/eigenpy/pull/487))
-- Fix compilation error on armhf ([#488](https://github.com/stack-of-tasks/eigenpy/pull/488)) 
+- Fix compilation error on armhf ([#488](https://github.com/stack-of-tasks/eigenpy/pull/488))
 
 ## [3.7.0] - 2024-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Remove CMake CMP0167 warnings ([#487](https://github.com/stack-of-tasks/eigenpy/pull/487))
+- Fix compilation error on armhf ([#488](https://github.com/stack-of-tasks/eigenpy/pull/488)) 
 
 ## [3.7.0] - 2024-06-11
 

--- a/include/eigenpy/numpy.hpp
+++ b/include/eigenpy/numpy.hpp
@@ -55,7 +55,7 @@ void EIGENPY_DLLAPI import_numpy();
 int EIGENPY_DLLAPI PyArray_TypeNum(PyTypeObject* type);
 
 // By default, the Scalar is considered as a Python object
-template <typename Scalar>
+template <typename Scalar, typename Enable = void>
 struct NumpyEquivalentType {
   enum { type_code = NPY_USERDEF };
 };
@@ -141,12 +141,16 @@ struct NumpyEquivalentType<unsigned long> {
 
 #include <type_traits>
 
-template <>
-struct NumpyEquivalentType<std::enable_if<!std::is_same<int64_t, long long>::value, long long>::type> {
+template <typename Scalar>
+struct NumpyEquivalentType<Scalar, std::enable_if_t<
+    !std::is_same<int64_t, long long>::value &&
+    std::is_same<Scalar, long long>::value>> {
   enum { type_code = NPY_LONGLONG };
 };
-template <>
-struct NumpyEquivalentType<std::enable_if<!std::is_same<uint64_t, unsigned long long>::value, unsigned long long>::type> {
+template <typename Scalar>
+struct NumpyEquivalentType<Scalar, std::enable_if_t<
+    !std::is_same<uint64_t, unsigned long long>::value &&
+    std::is_same<Scalar, unsigned long long>::value>> {
   enum { type_code = NPY_ULONGLONG };
 };
 

--- a/include/eigenpy/numpy.hpp
+++ b/include/eigenpy/numpy.hpp
@@ -142,15 +142,16 @@ struct NumpyEquivalentType<unsigned long> {
 #include <type_traits>
 
 template <typename Scalar>
-struct NumpyEquivalentType<Scalar, std::enable_if_t<
-    !std::is_same<int64_t, long long>::value &&
-    std::is_same<Scalar, long long>::value>> {
+struct NumpyEquivalentType<
+    Scalar, std::enable_if_t<!std::is_same<int64_t, long long>::value &&
+                             std::is_same<Scalar, long long>::value> > {
   enum { type_code = NPY_LONGLONG };
 };
 template <typename Scalar>
-struct NumpyEquivalentType<Scalar, std::enable_if_t<
-    !std::is_same<uint64_t, unsigned long long>::value &&
-    std::is_same<Scalar, unsigned long long>::value>> {
+struct NumpyEquivalentType<
+    Scalar,
+    std::enable_if_t<!std::is_same<uint64_t, unsigned long long>::value &&
+                     std::is_same<Scalar, unsigned long long>::value> > {
   enum { type_code = NPY_ULONGLONG };
 };
 

--- a/include/eigenpy/numpy.hpp
+++ b/include/eigenpy/numpy.hpp
@@ -139,12 +139,14 @@ struct NumpyEquivalentType<unsigned long> {
 // See https://github.com/stack-of-tasks/eigenpy/pull/455
 #if defined __linux__
 
+#include <type_traits>
+
 template <>
-struct NumpyEquivalentType<long long> {
+struct NumpyEquivalentType<std::enable_if<!std::is_same<int64_t, long long>::value, long long>::type> {
   enum { type_code = NPY_LONGLONG };
 };
 template <>
-struct NumpyEquivalentType<unsigned long long> {
+struct NumpyEquivalentType<std::enable_if<!std::is_same<uint64_t, unsigned long long>::value, unsigned long long>::type> {
   enum { type_code = NPY_ULONGLONG };
 };
 


### PR DESCRIPTION
The ROS Noetic armhf build for `eigenpy` is failing - likely caused by #455, and it's causing [regressions blocking the Noetic Sync](https://repositories.ros.org/status_page/ros_noetic_ufhf.html?q=REGRESSION). May I request a release to Noetic when this PR or another fix for the issue is merged?

This fixes the issue by using SFINAE and partial template specialization([as suggested here](https://stackoverflow.com/a/4166592)) to remove the specializations of `NumpyEquivalentType<long long>` and `NumpyEquivalentType<unsigned long long>` when they're the same as `int64_t` and `uint64_t` respectively.

https://build.ros.org/view/Nbin_ufhf_uFhf/job/Nbin_ufhf_uFhf__eigenpy__ubuntu_focal_armhf__binary/96

```
23:06:42 /usr/lib/ccache/c++  -Deigenpy_EXPORTS -I/tmp/binarydeb/ros-noetic-eigenpy-3.7.0/.obj-arm-linux-gnueabihf -I/tmp/binarydeb/ros-noetic-eigenpy-3.7.0/include -isystem /tmp/binarydeb/ros-noetic-eigenpy-3.7.0/.obj-arm-linux-gnueabihf/include -isystem /usr/include/eigen3 -isystem /usr/lib/python3/dist-packages/numpy/core/include -isystem /usr/include/python3.8  -Wno-long-long -Wall -Wextra -Wcast-align -Wcast-qual -Wformat -Wwrite-strings -Wconversion -g -O2 -fdebug-prefix-map=/tmp/binarydeb/ros-noetic-eigenpy-3.7.0=. -fstack-protector-strong -Wformat -Werror=format-security -DNDEBUG -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC   -Wno-conversion -std=gnu++14 -o CMakeFiles/eigenpy.dir/src/solvers/preconditioners.cpp.o -c /tmp/binarydeb/ros-noetic-eigenpy-3.7.0/src/solvers/preconditioners.cpp
23:06:50 In file included from /tmp/binarydeb/ros-noetic-eigenpy-3.7.0/include/eigenpy/fwd.hpp:87,
23:06:50                  from /tmp/binarydeb/ros-noetic-eigenpy-3.7.0/include/eigenpy/solvers/BasicPreconditioners.hpp:11,
23:06:50                  from /tmp/binarydeb/ros-noetic-eigenpy-3.7.0/src/solvers/preconditioners.cpp:8:
23:06:50 /tmp/binarydeb/ros-noetic-eigenpy-3.7.0/include/eigenpy/numpy.hpp:143:8: error: redefinition of ‘struct eigenpy::NumpyEquivalentType<long long int>’
23:06:50   143 | struct NumpyEquivalentType<long long> {
23:06:50       |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
23:06:50 /tmp/binarydeb/ros-noetic-eigenpy-3.7.0/include/eigenpy/numpy.hpp:115:8: note: previous definition of ‘struct eigenpy::NumpyEquivalentType<long long int>’
23:06:50   115 | struct NumpyEquivalentType<int64_t> {
23:06:50       |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
23:06:50 /tmp/binarydeb/ros-noetic-eigenpy-3.7.0/include/eigenpy/numpy.hpp:147:8: error: redefinition of ‘struct eigenpy::NumpyEquivalentType<long long unsigned int>’
23:06:50   147 | struct NumpyEquivalentType<unsigned long long> {
23:06:50       |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
23:06:50 /tmp/binarydeb/ros-noetic-eigenpy-3.7.0/include/eigenpy/numpy.hpp:119:8: note: previous definition of ‘struct eigenpy::NumpyEquivalentType<long long unsigned int>’
23:06:50   119 | struct NumpyEquivalentType<uint64_t> {
23:06:50       |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
23:06:50 make[4]: *** [CMakeFiles/eigenpy.dir/build.make:66: CMakeFiles/eigenpy.dir/src/solvers/preconditioners.cpp.o] Error 1
```

I tested that eigenpy builds with this PR on an amd64 machine, but that of course won't show the build failure. Instead I made sure the method for the fix works using godbolt.org with the 32bit `ARM GCC 9.3.0` compiler option with the code below:

```c++
#include <cstdint>
#include <type_traits>

template<typename S, typename Enable = void>
struct FoobarType{};

template<>
struct FoobarType<int64_t>{};

template<typename S>
struct FoobarType<S, 
std::enable_if_t<
!std::is_same<int64_t, long long>::value &&
std::is_same<S, long long>::value>>{};

template<>
struct FoobarType<uint64_t>{};

template<typename S>
struct FoobarType<S, 
std::enable_if_t<
!std::is_same<uint64_t, unsigned long long>::value &&
std::is_same<S, unsigned long long>::value>>{};

int main() {
    FoobarType<long long> bar;
    FoobarType<int64_t> baz;

    FoobarType<unsigned long long> ubar;
    FoobarType<uint64_t> ubaz;
}
```