### PR TITLE
Nix

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,19 @@
+name: "CI - Nix"
+
+on:
+  push:
+
+jobs:
+  nix:
+    runs-on: "${{ matrix.os }}-latest"
+    strategy:
+      matrix:
+        os: [ubuntu, macos]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v27
+      - uses: cachix/cachix-action@v15
+        with:
+          name: gepetto
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - run: nix build -L

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,58 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1722555600,
+        "narHash": "sha256-XOQkdLafnb/p9ij77byFQjDf5m5QYl9b2REiVClC+x4=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "8471fe90ad337a8074e957b69ca4d0089218391d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1724479785,
+        "narHash": "sha256-pP3Azj5d6M5nmG68Fu4JqZmdGt4S4vqI5f8te+E/FTw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d0e1602ddde669d5beb01aec49d71a51937ed7be",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1722555339,
+        "narHash": "sha256-uFf2QeW7eAHlYXuDktm9c25OxOyCoUOQmh5SZ9amE5Q=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,40 @@
+{
+  description = "Bindings between Numpy and Eigen using Boost.Python";
+
+  inputs = {
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    inputs:
+    inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = inputs.nixpkgs.lib.systems.flakeExposed;
+      perSystem =
+        { pkgs, self', ... }:
+        {
+          apps.default = {
+            type = "app";
+            program = pkgs.python3.withPackages (_: [ self'.packages.default ]);
+          };
+          devShells.default = pkgs.mkShell { inputsFrom = [ self'.packages.default ]; };
+          packages = {
+            default = self'.packages.eigenpy;
+            eigenpy = pkgs.python3Packages.eigenpy.overrideAttrs (_: {
+              src = pkgs.lib.fileset.toSource {
+                root = ./.;
+                fileset = pkgs.lib.fileset.unions [
+                  ./CMakeLists.txt
+                  ./doc
+                  ./include
+                  ./package.xml
+                  ./python
+                  ./src
+                  ./unittest
+                ];
+              };
+            });
+          };
+        };
+    };
+}


### PR DESCRIPTION
Hi,

This add some features related to Nix, including:

### An override

eigenpy is available in [nixpkgs], so defining another version of the package based on git is only a matter of overriding the source specification from there.

This override filter some files/dirs among the git tracked sources, to avoid rebuilding when only README / CHANGELOG / other metadata files change.

This package can then be built with `nix build`. The result will be available in the nix store, with a `result` symlink to it. Build logs can be streamed to the current stdout with the `-L` flag.

### A flake

Since the overridden package is provided in a flake, the git repository become usable directly from nix, including:
- a way for other nix flakes to reference and use any given version of this package, eg:
  - `github:stack-of-tasks/eigenpy/9fa85b547c9ef0ba3bcd5297b4050f15769c61b3`: from a commit hash
  - `github:stack-of-tasks/eigenpy/9fa85b5`: from a short rev
  - `github:stack-of-tasks/eigenpy/nix`: from a branch
  - `github:stack-of-tasks/eigenpy/vX.Y.Z`: from a tag (once this will be merged a tag including this will be available)
  - `github:stack-of-tasks/eigenpy`: from the repo (once this will be merged into master, which is the default branch)
  - `/path/to/eigenpy`: from a local clone absolute path
  - `.`: from a local clone relative path
  - (nothing): this is a short hand for `.`
- a way to build those: `nix build $REF`
- a way to run eigenpy directly:
  - `nix run $REF` will start a python interpreter with eigenpy installed.
  - eg. `nix run github:stack-of-tasks/eigenpy/nix -- -c "import eigenpy; print(eigenpy.__version__)"` => `3.8.2`
- a development shell:
  - `nix develop $REF` will start a shell with all eigenpy dependencies available. At this point, eg. classical `cmake -B build -S . && cmake --build build` will work directly.
  - with `echo "use flake" > .envrc && direnv allow` and [nix-direnv](https://github.com/nix-community/nix-direnv), this shell will automatically activate itself on entering into the directory, and deactivate itself on leaving.

### CI jobs

Linux and MacOS jobs on Github Action will run `nix build`, allowing to detect early:
- if anything new in the repo would break the nix packaging
- if any update from a dependency in upstream [nixpkgs] would break eigenpy

### A binary cache

The CI jobs will push the built packages to https://gepetto.cachix.org, so users won't have to build a version which was already built by CI.
And vice-versa, users will be able to push to that cache, so that those CI jobs can be no-op.


[nixpkgs]: https://github.com/NixOS/nixpkgs/