### PR TITLE
[std-vector.hpp] make std::vector allocator type a template parameter for exposeStdVectorEigenSpecificType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- The `exposeStdVectorEigenSpecificType()` template function now takes the vector allocator as a template parameter.
+
 ## [3.8.2] - 2024-08-26
 
 ### Fixed

--- a/include/eigenpy/std-vector.hpp
+++ b/include/eigenpy/std-vector.hpp
@@ -485,9 +485,9 @@ struct StdVectorPythonVisitor {
  */
 void EIGENPY_DLLAPI exposeStdVector();
 
-template <typename MatType>
+template <typename MatType, typename Alloc = Eigen::aligned_allocator<MatType> >
 void exposeStdVectorEigenSpecificType(const char *name) {
-  typedef std::vector<MatType, Eigen::aligned_allocator<MatType> > VecMatType;
+  typedef std::vector<MatType, Alloc> VecMatType;
   std::string full_name = "StdVec_";
   full_name += name;
   StdVectorPythonVisitor<VecMatType>::expose(


### PR DESCRIPTION
This PR adds the `std::vector` allocator type as a template parameter for the `exposeStdVectorEigenSpecificType()` convenience function.

This would be useful in C++17 codebases wherein `Eigen::aligned_allocator<T>` is no longer useful (as outlined [in the executive summary here](https://www.eigen.tuxfamily.org/dox-devel/group__TopicStlContainers.html)) and developers would want to stay with the default allocator.