### PR TITLE
[std-map] add more general visitor for map types, fix non-default-constructible types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+
+- Add more general visitor `GenericMapPythonVisitor` for map types ([#504](https://github.com/stack-of-tasks/eigenpy/pull/504)), test `boost::unordered_map<std::string, int>`
 - Add type_info helpers ([#502](https://github.com/stack-of-tasks/eigenpy/pull/502))
+
+### Changed
+
+- Move `StdMapPythonVisitor` out of `eigenpy::python` namespace, which was a mistake ([#504](https://github.com/stack-of-tasks/eigenpy/pull/504))
 
 ## [3.9.0] - 2024-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Add more general visitor `GenericMapPythonVisitor` for map types ([#504](https://github.com/stack-of-tasks/eigenpy/pull/504)), test `boost::unordered_map<std::string, int>`
+- Add more general visitor `GenericMapPythonVisitor` for map types test `boost::unordered_map<std::string, int>` ([#504](https://github.com/stack-of-tasks/eigenpy/pull/504))
+- Support for non-[default-contructible](https://en.cppreference.com/w/cpp/named_req/DefaultConstructible) types in map types ([#504](https://github.com/stack-of-tasks/eigenpy/pull/504))
 - Add type_info helpers ([#502](https://github.com/stack-of-tasks/eigenpy/pull/502))
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -14,15 +14,16 @@ EigenPy — Versatile and efficient Python bindings between Numpy and Eigen
 **EigenPy** is an open-source framework that allows the binding of the famous [Eigen](http://eigen.tuxfamily.org) C++ library in Python via Boost.Python.
 
 **EigenPy** provides:
- - full memory sharing between Numpy and Eigen, avoiding memory allocation
- - full support Eigen::Ref avoiding memory allocation
- - full support of the Eigen::Tensor module
- - exposition of the Geometry module of Eigen for easy code prototyping
- - standard matrix decomposion routines of Eigen such as the Cholesky decomposition (SVD and QR decompositions [can be added](#contributing))
- - full support of SWIG objects
- - full support of runtime declaration of Numpy scalar types
- - extended API to expose std::vector types
- - full support of vectorization between C++ and Python (all the hold objects are properly aligned in memory)
+
+- full memory sharing between Numpy and Eigen, avoiding memory allocation
+- full support Eigen::Ref avoiding memory allocation
+- full support of the Eigen::Tensor module
+- exposition of the Geometry module of Eigen for easy code prototyping
+- standard matrix decomposion routines of Eigen such as the Cholesky decomposition (SVD and QR decompositions [can be added](#contributing))
+- full support of SWIG objects
+- full support of runtime declaration of Numpy scalar types
+- extended API to expose several STL types and some of their Boost equivalents: `optional` types, `std::pair`, maps, variants...
+- full support of vectorization between C++ and Python (all the hold objects are properly aligned in memory)
 
 ## Setup
 

--- a/include/eigenpy/std-map.hpp
+++ b/include/eigenpy/std-map.hpp
@@ -142,7 +142,7 @@ struct dict_to_map {
         bp::throw_error_already_set();
       }
       typename Container::mapped_type val = valproxy();
-      map[key] = val;
+      map.emplace(key, val);
     }
 
     // remember the location for later

--- a/unittest/python/test_std_map.py
+++ b/unittest/python/test_std_map.py
@@ -1,6 +1,9 @@
-from std_map import copy, std_map_to_dict
+from std_map import copy, copy_boost, std_map_to_dict
 
 t = {"one": 1.0, "two": 2.0}
+t2 = {"one": 1, "two": 2, "three": 3}
 
 assert std_map_to_dict(t) == t
 assert std_map_to_dict(copy(t)) == t
+m = copy_boost(t2)
+assert m.todict() == t2

--- a/unittest/std_map.cpp
+++ b/unittest/std_map.cpp
@@ -31,7 +31,7 @@ boost::unordered_map<std::string, T1> copy_boost(
 BOOST_PYTHON_MODULE(std_map) {
   eigenpy::enableEigenPy();
 
-  eigenpy::python::StdMapPythonVisitor<
+  eigenpy::StdMapPythonVisitor<
       std::string, double, std::less<std::string>,
       std::allocator<std::pair<const std::string, double> >,
       true>::expose("StdMap_Double");

--- a/unittest/std_map.cpp
+++ b/unittest/std_map.cpp
@@ -28,6 +28,12 @@ boost::unordered_map<std::string, T1> copy_boost(
   return obj;
 }
 
+struct X {
+  X() = delete;
+  X(int x) : val(x) {}
+  int val;
+};
+
 BOOST_PYTHON_MODULE(std_map) {
   eigenpy::enableEigenPy();
 
@@ -38,6 +44,8 @@ BOOST_PYTHON_MODULE(std_map) {
 
   eigenpy::GenericMapVisitor<boost::unordered_map<std::string, int> >::expose(
       "boost_map_int");
+
+  eigenpy::GenericMapVisitor<std::map<std::string, X> >::expose("StdMap_X");
 
   bp::def("std_map_to_dict", std_map_to_dict<double>);
   bp::def("copy", copy<double>);

--- a/unittest/std_map.cpp
+++ b/unittest/std_map.cpp
@@ -3,7 +3,7 @@
 
 #include <eigenpy/eigenpy.hpp>
 #include <eigenpy/std-map.hpp>
-#include <iostream>
+#include <boost/unordered_map.hpp>
 
 namespace bp = boost::python;
 
@@ -22,6 +22,12 @@ std::map<std::string, T1> copy(const std::map<std::string, T1>& map) {
   return out;
 }
 
+template <typename T1>
+boost::unordered_map<std::string, T1> copy_boost(
+    const boost::unordered_map<std::string, T1>& obj) {
+  return obj;
+}
+
 BOOST_PYTHON_MODULE(std_map) {
   eigenpy::enableEigenPy();
 
@@ -30,6 +36,10 @@ BOOST_PYTHON_MODULE(std_map) {
       std::allocator<std::pair<const std::string, double> >,
       true>::expose("StdMap_Double");
 
+  eigenpy::GenericMapVisitor<boost::unordered_map<std::string, int> >::expose(
+      "boost_map_int");
+
   bp::def("std_map_to_dict", std_map_to_dict<double>);
   bp::def("copy", copy<double>);
+  bp::def("copy_boost", copy_boost<int>);
 }


### PR DESCRIPTION
+ test boost::unordered_map
+ pull StdMapPythonVisitor out of eigenpy::python namespace (shouldn't exist, add using-decl for backwards compatibility)
