### PR TITLE
Update C++ standard for clang-format to 11, apply updated formatting rules

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,3 +1,3 @@
 BasedOnStyle: Google
 SortIncludes: false
-Standard: Cpp03
+Standard: Cpp11

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -6,3 +6,6 @@
 
 # pre-commit run -a (Guilhem Saurel, 2024-02-19)
 0bae435330ee475f8dbb11bf5e672284d294d9b3
+
+# pre-commit run -a (ManifoldFR, 2025-04-25)
+51b49061575d46e0668eba0da200217cbfd9e883

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,8 +26,6 @@ repos:
   rev: v20.1.0
   hooks:
   - id: clang-format
-    args:
-    - '--style={BasedOnStyle: Google, SortIncludes: false, Standard: Cpp03}'
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v5.0.0
   hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fix handling of non sorted sparse matrix ([#538](https://github.com/stack-of-tasks/eigenpy/pull/538))
 
+### Changed
+
+- Update clang-format standard to C++11, reformat code
+
 ## [3.10.3] - 2025-02-11
 
 ### Added

--- a/include/eigenpy/alignment.hpp
+++ b/include/eigenpy/alignment.hpp
@@ -108,8 +108,8 @@ namespace objects {
 
 // Force alignment of instance with value_holder
 template <typename Derived>
-struct instance<value_holder<Derived> >
-    : ::eigenpy::aligned_instance<value_holder<Derived> > {};
+struct instance<value_holder<Derived>>
+    : ::eigenpy::aligned_instance<value_holder<Derived>> {};
 
 }  // namespace objects
 }  // namespace python

--- a/include/eigenpy/angle-axis.hpp
+++ b/include/eigenpy/angle-axis.hpp
@@ -13,7 +13,7 @@ template <typename AngleAxis>
 class AngleAxisVisitor;
 
 template <typename Scalar>
-struct call<Eigen::AngleAxis<Scalar> > {
+struct call<Eigen::AngleAxis<Scalar>> {
   typedef Eigen::AngleAxis<Scalar> AngleAxis;
 
   static inline void expose() { AngleAxisVisitor<AngleAxis>::expose(); }
@@ -26,7 +26,7 @@ struct call<Eigen::AngleAxis<Scalar> > {
 };
 
 template <typename AngleAxis>
-class AngleAxisVisitor : public bp::def_visitor<AngleAxisVisitor<AngleAxis> > {
+class AngleAxisVisitor : public bp::def_visitor<AngleAxisVisitor<AngleAxis>> {
   typedef typename AngleAxis::Scalar Scalar;
   typedef typename AngleAxis::Vector3 Vector3;
   typedef typename AngleAxis::Matrix3 Matrix3;

--- a/include/eigenpy/copyable.hpp
+++ b/include/eigenpy/copyable.hpp
@@ -15,7 +15,7 @@ namespace eigenpy {
 /// copy constructor.
 ///
 template <class C>
-struct CopyableVisitor : public bp::def_visitor<CopyableVisitor<C> > {
+struct CopyableVisitor : public bp::def_visitor<CopyableVisitor<C>> {
   template <class PyClass>
   void visit(PyClass& cl) const {
     cl.def("copy", &copy, bp::arg("self"), "Returns a copy of *this.");

--- a/include/eigenpy/decompositions/ColPivHouseholderQR.hpp
+++ b/include/eigenpy/decompositions/ColPivHouseholderQR.hpp
@@ -15,7 +15,7 @@ namespace eigenpy {
 template <typename _MatrixType>
 struct ColPivHouseholderQRSolverVisitor
     : public boost::python::def_visitor<
-          ColPivHouseholderQRSolverVisitor<_MatrixType> > {
+          ColPivHouseholderQRSolverVisitor<_MatrixType>> {
   typedef _MatrixType MatrixType;
   typedef typename MatrixType::Scalar Scalar;
   typedef typename MatrixType::RealScalar RealScalar;

--- a/include/eigenpy/decompositions/CompleteOrthogonalDecomposition.hpp
+++ b/include/eigenpy/decompositions/CompleteOrthogonalDecomposition.hpp
@@ -15,7 +15,7 @@ namespace eigenpy {
 template <typename _MatrixType>
 struct CompleteOrthogonalDecompositionSolverVisitor
     : public boost::python::def_visitor<
-          CompleteOrthogonalDecompositionSolverVisitor<_MatrixType> > {
+          CompleteOrthogonalDecompositionSolverVisitor<_MatrixType>> {
   typedef _MatrixType MatrixType;
   typedef typename MatrixType::Scalar Scalar;
   typedef typename MatrixType::RealScalar RealScalar;

--- a/include/eigenpy/decompositions/EigenSolver.hpp
+++ b/include/eigenpy/decompositions/EigenSolver.hpp
@@ -16,7 +16,7 @@ namespace eigenpy {
 
 template <typename _MatrixType>
 struct EigenSolverVisitor
-    : public boost::python::def_visitor<EigenSolverVisitor<_MatrixType> > {
+    : public boost::python::def_visitor<EigenSolverVisitor<_MatrixType>> {
   typedef _MatrixType MatrixType;
   typedef typename MatrixType::Scalar Scalar;
   typedef Eigen::EigenSolver<MatrixType> Solver;
@@ -26,7 +26,7 @@ struct EigenSolverVisitor
     cl.def(bp::init<>("Default constructor"))
         .def(bp::init<Eigen::DenseIndex>(
             bp::arg("size"), "Default constructor with memory preallocation"))
-        .def(bp::init<MatrixType, bp::optional<bool> >(
+        .def(bp::init<MatrixType, bp::optional<bool>>(
             bp::args("matrix", "compute_eigen_vectors"),
             "Computes eigendecomposition of given matrix"))
 

--- a/include/eigenpy/decompositions/FullPivHouseholderQR.hpp
+++ b/include/eigenpy/decompositions/FullPivHouseholderQR.hpp
@@ -15,7 +15,7 @@ namespace eigenpy {
 template <typename _MatrixType>
 struct FullPivHouseholderQRSolverVisitor
     : public boost::python::def_visitor<
-          FullPivHouseholderQRSolverVisitor<_MatrixType> > {
+          FullPivHouseholderQRSolverVisitor<_MatrixType>> {
   typedef _MatrixType MatrixType;
   typedef typename MatrixType::Scalar Scalar;
   typedef typename MatrixType::RealScalar RealScalar;

--- a/include/eigenpy/decompositions/HouseholderQR.hpp
+++ b/include/eigenpy/decompositions/HouseholderQR.hpp
@@ -15,7 +15,7 @@ namespace eigenpy {
 template <typename _MatrixType>
 struct HouseholderQRSolverVisitor
     : public boost::python::def_visitor<
-          HouseholderQRSolverVisitor<_MatrixType> > {
+          HouseholderQRSolverVisitor<_MatrixType>> {
   typedef _MatrixType MatrixType;
   typedef typename MatrixType::Scalar Scalar;
   typedef typename MatrixType::RealScalar RealScalar;

--- a/include/eigenpy/decompositions/LDLT.hpp
+++ b/include/eigenpy/decompositions/LDLT.hpp
@@ -16,7 +16,7 @@ namespace eigenpy {
 
 template <typename _MatrixType>
 struct LDLTSolverVisitor
-    : public boost::python::def_visitor<LDLTSolverVisitor<_MatrixType> > {
+    : public boost::python::def_visitor<LDLTSolverVisitor<_MatrixType>> {
   typedef _MatrixType MatrixType;
   typedef typename MatrixType::Scalar Scalar;
   typedef typename MatrixType::RealScalar RealScalar;

--- a/include/eigenpy/decompositions/LLT.hpp
+++ b/include/eigenpy/decompositions/LLT.hpp
@@ -16,7 +16,7 @@ namespace eigenpy {
 
 template <typename _MatrixType>
 struct LLTSolverVisitor
-    : public boost::python::def_visitor<LLTSolverVisitor<_MatrixType> > {
+    : public boost::python::def_visitor<LLTSolverVisitor<_MatrixType>> {
   typedef _MatrixType MatrixType;
   typedef typename MatrixType::Scalar Scalar;
   typedef typename MatrixType::RealScalar RealScalar;

--- a/include/eigenpy/decompositions/PermutationMatrix.hpp
+++ b/include/eigenpy/decompositions/PermutationMatrix.hpp
@@ -14,7 +14,7 @@ template <int SizeAtCompileTime, int MaxSizeAtCompileTime = SizeAtCompileTime,
           typename StorageIndex_ = int>
 struct PermutationMatrixVisitor
     : public boost::python::def_visitor<PermutationMatrixVisitor<
-          SizeAtCompileTime, MaxSizeAtCompileTime, StorageIndex_> > {
+          SizeAtCompileTime, MaxSizeAtCompileTime, StorageIndex_>> {
   typedef StorageIndex_ StorageIndex;
   typedef Eigen::PermutationMatrix<SizeAtCompileTime, MaxSizeAtCompileTime,
                                    StorageIndex>

--- a/include/eigenpy/decompositions/SelfAdjointEigenSolver.hpp
+++ b/include/eigenpy/decompositions/SelfAdjointEigenSolver.hpp
@@ -17,7 +17,7 @@ namespace eigenpy {
 template <typename _MatrixType>
 struct SelfAdjointEigenSolverVisitor
     : public boost::python::def_visitor<
-          SelfAdjointEigenSolverVisitor<_MatrixType> > {
+          SelfAdjointEigenSolverVisitor<_MatrixType>> {
   typedef _MatrixType MatrixType;
   typedef typename MatrixType::Scalar Scalar;
   typedef Eigen::SelfAdjointEigenSolver<MatrixType> Solver;
@@ -28,7 +28,7 @@ struct SelfAdjointEigenSolverVisitor
         .def(bp::init<Eigen::DenseIndex>(
             bp::args("self", "size"),
             "Default constructor with memory preallocation"))
-        .def(bp::init<MatrixType, bp::optional<int> >(
+        .def(bp::init<MatrixType, bp::optional<int>>(
             bp::args("self", "matrix", "options"),
             "Computes eigendecomposition of given matrix"))
 

--- a/include/eigenpy/decompositions/minres.hpp
+++ b/include/eigenpy/decompositions/minres.hpp
@@ -15,7 +15,7 @@
 namespace eigenpy {
 template <typename _Solver>
 struct IterativeSolverBaseVisitor
-    : public boost::python::def_visitor<IterativeSolverBaseVisitor<_Solver> > {
+    : public boost::python::def_visitor<IterativeSolverBaseVisitor<_Solver>> {
   typedef _Solver Solver;
   typedef typename Solver::MatrixType MatrixType;
   typedef typename Solver::Preconditioner Preconditioner;
@@ -123,7 +123,7 @@ struct IterativeSolverBaseVisitor
 
 template <typename _MatrixType>
 struct MINRESSolverVisitor
-    : public boost::python::def_visitor<MINRESSolverVisitor<_MatrixType> > {
+    : public boost::python::def_visitor<MINRESSolverVisitor<_MatrixType>> {
   typedef _MatrixType MatrixType;
   typedef typename MatrixType::Scalar Scalar;
   typedef typename MatrixType::RealScalar RealScalar;

--- a/include/eigenpy/decompositions/sparse/LDLT.hpp
+++ b/include/eigenpy/decompositions/sparse/LDLT.hpp
@@ -13,10 +13,10 @@ namespace eigenpy {
 
 template <typename _MatrixType, int _UpLo = Eigen::Lower,
           typename _Ordering =
-              Eigen::AMDOrdering<typename _MatrixType::StorageIndex> >
+              Eigen::AMDOrdering<typename _MatrixType::StorageIndex>>
 struct SimplicialLDLTVisitor
     : public boost::python::def_visitor<
-          SimplicialLDLTVisitor<_MatrixType, _UpLo, _Ordering> > {
+          SimplicialLDLTVisitor<_MatrixType, _UpLo, _Ordering>> {
   typedef SimplicialLDLTVisitor<_MatrixType, _UpLo, _Ordering> Visitor;
   typedef _MatrixType MatrixType;
 

--- a/include/eigenpy/decompositions/sparse/LLT.hpp
+++ b/include/eigenpy/decompositions/sparse/LLT.hpp
@@ -13,10 +13,10 @@ namespace eigenpy {
 
 template <typename _MatrixType, int _UpLo = Eigen::Lower,
           typename _Ordering =
-              Eigen::AMDOrdering<typename _MatrixType::StorageIndex> >
+              Eigen::AMDOrdering<typename _MatrixType::StorageIndex>>
 struct SimplicialLLTVisitor
     : public boost::python::def_visitor<
-          SimplicialLLTVisitor<_MatrixType, _UpLo, _Ordering> > {
+          SimplicialLLTVisitor<_MatrixType, _UpLo, _Ordering>> {
   typedef SimplicialLLTVisitor<_MatrixType, _UpLo, _Ordering> Visitor;
   typedef _MatrixType MatrixType;
 

--- a/include/eigenpy/decompositions/sparse/SimplicialCholesky.hpp
+++ b/include/eigenpy/decompositions/sparse/SimplicialCholesky.hpp
@@ -16,7 +16,7 @@ namespace eigenpy {
 template <typename SimplicialDerived>
 struct SimplicialCholeskyVisitor
     : public boost::python::def_visitor<
-          SimplicialCholeskyVisitor<SimplicialDerived> > {
+          SimplicialCholeskyVisitor<SimplicialDerived>> {
   typedef SimplicialDerived Solver;
 
   typedef typename SimplicialDerived::MatrixType MatrixType;

--- a/include/eigenpy/decompositions/sparse/SparseSolverBase.hpp
+++ b/include/eigenpy/decompositions/sparse/SparseSolverBase.hpp
@@ -15,7 +15,7 @@ namespace eigenpy {
 template <typename SimplicialDerived>
 struct SparseSolverBaseVisitor
     : public boost::python::def_visitor<
-          SparseSolverBaseVisitor<SimplicialDerived> > {
+          SparseSolverBaseVisitor<SimplicialDerived>> {
   typedef SimplicialDerived Solver;
 
   typedef typename SimplicialDerived::MatrixType MatrixType;

--- a/include/eigenpy/decompositions/sparse/accelerate/accelerate.hpp
+++ b/include/eigenpy/decompositions/sparse/accelerate/accelerate.hpp
@@ -15,7 +15,7 @@ namespace eigenpy {
 
 template <typename AccelerateDerived>
 struct AccelerateImplVisitor : public boost::python::def_visitor<
-                                   AccelerateImplVisitor<AccelerateDerived> > {
+                                   AccelerateImplVisitor<AccelerateDerived>> {
   typedef AccelerateDerived Solver;
 
   typedef typename AccelerateDerived::MatrixType MatrixType;

--- a/include/eigenpy/decompositions/sparse/cholmod/CholmodBase.hpp
+++ b/include/eigenpy/decompositions/sparse/cholmod/CholmodBase.hpp
@@ -15,7 +15,7 @@ namespace eigenpy {
 
 template <typename CholdmodDerived>
 struct CholmodBaseVisitor
-    : public boost::python::def_visitor<CholmodBaseVisitor<CholdmodDerived> > {
+    : public boost::python::def_visitor<CholmodBaseVisitor<CholdmodDerived>> {
   typedef CholdmodDerived Solver;
 
   typedef typename CholdmodDerived::MatrixType MatrixType;

--- a/include/eigenpy/decompositions/sparse/cholmod/CholmodDecomposition.hpp
+++ b/include/eigenpy/decompositions/sparse/cholmod/CholmodDecomposition.hpp
@@ -13,7 +13,7 @@ namespace eigenpy {
 template <typename CholdmodDerived>
 struct CholmodDecompositionVisitor
     : public boost::python::def_visitor<
-          CholmodDecompositionVisitor<CholdmodDerived> > {
+          CholmodDecompositionVisitor<CholdmodDerived>> {
   typedef CholdmodDerived Solver;
 
   template <class PyClass>

--- a/include/eigenpy/decompositions/sparse/cholmod/CholmodSimplicialLDLT.hpp
+++ b/include/eigenpy/decompositions/sparse/cholmod/CholmodSimplicialLDLT.hpp
@@ -14,7 +14,7 @@ namespace eigenpy {
 template <typename MatrixType_, int UpLo_ = Eigen::Lower>
 struct CholmodSimplicialLDLTVisitor
     : public boost::python::def_visitor<
-          CholmodSimplicialLDLTVisitor<MatrixType_, UpLo_> > {
+          CholmodSimplicialLDLTVisitor<MatrixType_, UpLo_>> {
   typedef MatrixType_ MatrixType;
   typedef typename MatrixType::Scalar Scalar;
   typedef typename MatrixType::RealScalar RealScalar;

--- a/include/eigenpy/decompositions/sparse/cholmod/CholmodSimplicialLLT.hpp
+++ b/include/eigenpy/decompositions/sparse/cholmod/CholmodSimplicialLLT.hpp
@@ -14,7 +14,7 @@ namespace eigenpy {
 template <typename MatrixType_, int UpLo_ = Eigen::Lower>
 struct CholmodSimplicialLLTVisitor
     : public boost::python::def_visitor<
-          CholmodSimplicialLLTVisitor<MatrixType_, UpLo_> > {
+          CholmodSimplicialLLTVisitor<MatrixType_, UpLo_>> {
   typedef MatrixType_ MatrixType;
   typedef typename MatrixType::Scalar Scalar;
   typedef typename MatrixType::RealScalar RealScalar;

--- a/include/eigenpy/decompositions/sparse/cholmod/CholmodSupernodalLLT.hpp
+++ b/include/eigenpy/decompositions/sparse/cholmod/CholmodSupernodalLLT.hpp
@@ -14,7 +14,7 @@ namespace eigenpy {
 template <typename MatrixType_, int UpLo_ = Eigen::Lower>
 struct CholmodSupernodalLLTVisitor
     : public boost::python::def_visitor<
-          CholmodSupernodalLLTVisitor<MatrixType_, UpLo_> > {
+          CholmodSupernodalLLTVisitor<MatrixType_, UpLo_>> {
   typedef MatrixType_ MatrixType;
   typedef typename MatrixType::Scalar Scalar;
   typedef typename MatrixType::RealScalar RealScalar;

--- a/include/eigenpy/details.hpp
+++ b/include/eigenpy/details.hpp
@@ -31,8 +31,8 @@ struct expose_eigen_type_impl<MatType, Eigen::MatrixBase<MatType>, Scalar> {
     // to-python
     EigenToPyConverter<MatType>::registration();
 #if EIGEN_VERSION_AT_LEAST(3, 2, 0)
-    EigenToPyConverter<Eigen::Ref<MatType> >::registration();
-    EigenToPyConverter<const Eigen::Ref<const MatType> >::registration();
+    EigenToPyConverter<Eigen::Ref<MatType>>::registration();
+    EigenToPyConverter<const Eigen::Ref<const MatType>>::registration();
 #endif
 
     // from-python
@@ -67,9 +67,9 @@ struct expose_eigen_type_impl<TensorType, Eigen::TensorBase<TensorType>,
 
     // to-python
     EigenToPyConverter<TensorType>::registration();
-    EigenToPyConverter<Eigen::TensorRef<TensorType> >::registration();
+    EigenToPyConverter<Eigen::TensorRef<TensorType>>::registration();
     EigenToPyConverter<
-        const Eigen::TensorRef<const TensorType> >::registration();
+        const Eigen::TensorRef<const TensorType>>::registration();
 
     // from-python
     EigenFromPyConverter<TensorType>::registration();

--- a/include/eigenpy/eigen-allocator.hpp
+++ b/include/eigenpy/eigen-allocator.hpp
@@ -98,7 +98,7 @@ template <typename EigenType,
 struct check_swap_impl;
 
 template <typename MatType>
-struct check_swap_impl<MatType, Eigen::MatrixBase<MatType> >
+struct check_swap_impl<MatType, Eigen::MatrixBase<MatType>>
     : check_swap_impl_matrix<MatType> {};
 
 template <typename MatType>
@@ -127,7 +127,7 @@ struct check_swap_impl_tensor {
 };
 
 template <typename TensorType>
-struct check_swap_impl<TensorType, Eigen::TensorBase<TensorType> >
+struct check_swap_impl<TensorType, Eigen::TensorBase<TensorType>>
     : check_swap_impl_tensor<TensorType> {};
 #endif
 
@@ -294,11 +294,11 @@ template <typename MatType>
 struct eigen_allocator_impl_matrix;
 
 template <typename MatType>
-struct eigen_allocator_impl<MatType, Eigen::MatrixBase<MatType> >
+struct eigen_allocator_impl<MatType, Eigen::MatrixBase<MatType>>
     : eigen_allocator_impl_matrix<MatType> {};
 
 template <typename MatType>
-struct eigen_allocator_impl<const MatType, const Eigen::MatrixBase<MatType> >
+struct eigen_allocator_impl<const MatType, const Eigen::MatrixBase<MatType>>
     : eigen_allocator_impl_matrix<const MatType> {};
 
 template <typename MatType>
@@ -362,12 +362,12 @@ template <typename TensorType>
 struct eigen_allocator_impl_tensor;
 
 template <typename TensorType>
-struct eigen_allocator_impl<TensorType, Eigen::TensorBase<TensorType> >
+struct eigen_allocator_impl<TensorType, Eigen::TensorBase<TensorType>>
     : eigen_allocator_impl_tensor<TensorType> {};
 
 template <typename TensorType>
 struct eigen_allocator_impl<const TensorType,
-                            const Eigen::TensorBase<TensorType> >
+                            const Eigen::TensorBase<TensorType>>
     : eigen_allocator_impl_tensor<const TensorType> {};
 
 template <typename TensorType>
@@ -462,7 +462,7 @@ inline bool is_arr_layout_compatible_with_mat_type(PyArrayObject *pyArray) {
 }
 
 template <typename MatType, int Options, typename Stride>
-struct eigen_allocator_impl_matrix<Eigen::Ref<MatType, Options, Stride> > {
+struct eigen_allocator_impl_matrix<Eigen::Ref<MatType, Options, Stride>> {
   typedef Eigen::Ref<MatType, Options, Stride> RefType;
   typedef typename MatType::Scalar Scalar;
 
@@ -523,7 +523,7 @@ struct eigen_allocator_impl_matrix<Eigen::Ref<MatType, Options, Stride> > {
 
 template <typename MatType, int Options, typename Stride>
 struct eigen_allocator_impl_matrix<
-    const Eigen::Ref<const MatType, Options, Stride> > {
+    const Eigen::Ref<const MatType, Options, Stride>> {
   typedef const Eigen::Ref<const MatType, Options, Stride> RefType;
   typedef typename MatType::Scalar Scalar;
 
@@ -590,14 +590,14 @@ template <typename TensorType, typename TensorRef>
 struct eigen_allocator_impl_tensor_ref;
 
 template <typename TensorType>
-struct eigen_allocator_impl_tensor<Eigen::TensorRef<TensorType> >
+struct eigen_allocator_impl_tensor<Eigen::TensorRef<TensorType>>
     : eigen_allocator_impl_tensor_ref<TensorType,
-                                      Eigen::TensorRef<TensorType> > {};
+                                      Eigen::TensorRef<TensorType>> {};
 
 template <typename TensorType>
-struct eigen_allocator_impl_tensor<const Eigen::TensorRef<const TensorType> >
+struct eigen_allocator_impl_tensor<const Eigen::TensorRef<const TensorType>>
     : eigen_allocator_impl_tensor_ref<
-          const TensorType, const Eigen::TensorRef<const TensorType> > {};
+          const TensorType, const Eigen::TensorRef<const TensorType>> {};
 
 template <typename TensorType, typename RefType>
 struct eigen_allocator_impl_tensor_ref {

--- a/include/eigenpy/eigen-from-python.hpp
+++ b/include/eigenpy/eigen-from-python.hpp
@@ -17,7 +17,7 @@ template <typename EigenType,
 struct expected_pytype_for_arg {};
 
 template <typename MatType>
-struct expected_pytype_for_arg<MatType, Eigen::MatrixBase<MatType> > {
+struct expected_pytype_for_arg<MatType, Eigen::MatrixBase<MatType>> {
   static PyTypeObject const *get_pytype() {
     PyTypeObject const *py_type = eigenpy::getPyArrayType();
     return py_type;
@@ -33,9 +33,9 @@ namespace converter {
 template <typename Scalar, int Rows, int Cols, int Options, int MaxRows,
           int MaxCols>
 struct expected_pytype_for_arg<
-    Eigen::Matrix<Scalar, Rows, Cols, Options, MaxRows, MaxCols> >
+    Eigen::Matrix<Scalar, Rows, Cols, Options, MaxRows, MaxCols>>
     : eigenpy::expected_pytype_for_arg<
-          Eigen::Matrix<Scalar, Rows, Cols, Options, MaxRows, MaxCols> > {};
+          Eigen::Matrix<Scalar, Rows, Cols, Options, MaxRows, MaxCols>> {};
 
 }  // namespace converter
 }  // namespace python
@@ -277,7 +277,7 @@ struct eigen_from_py_impl {
 };
 
 template <typename MatType>
-struct eigen_from_py_impl<MatType, Eigen::MatrixBase<MatType> > {
+struct eigen_from_py_impl<MatType, Eigen::MatrixBase<MatType>> {
   typedef typename MatType::Scalar Scalar;
 
   /// \brief Determine if pyObj can be converted into a MatType object
@@ -296,7 +296,7 @@ template <typename EigenType,
 struct EigenFromPy : eigen_from_py_impl<EigenType> {};
 
 template <typename MatType>
-void *eigen_from_py_impl<MatType, Eigen::MatrixBase<MatType> >::convertible(
+void *eigen_from_py_impl<MatType, Eigen::MatrixBase<MatType>>::convertible(
     PyObject *pyObj) {
   if (!call_PyArray_Check(reinterpret_cast<PyObject *>(pyObj))) return 0;
 
@@ -398,13 +398,13 @@ void *eigen_from_py_impl<MatType, Eigen::MatrixBase<MatType> >::convertible(
 }
 
 template <typename MatType>
-void eigen_from_py_impl<MatType, Eigen::MatrixBase<MatType> >::construct(
+void eigen_from_py_impl<MatType, Eigen::MatrixBase<MatType>>::construct(
     PyObject *pyObj, bp::converter::rvalue_from_python_stage1_data *memory) {
   eigen_from_py_construct<MatType>(pyObj, memory);
 }
 
 template <typename MatType>
-void eigen_from_py_impl<MatType, Eigen::MatrixBase<MatType> >::registration() {
+void eigen_from_py_impl<MatType, Eigen::MatrixBase<MatType>>::registration() {
   bp::converter::registry::push_back(
       reinterpret_cast<void *(*)(_object *)>(&eigen_from_py_impl::convertible),
       &eigen_from_py_impl::construct, bp::type_id<MatType>()
@@ -423,7 +423,7 @@ template <typename EigenType>
 struct EigenFromPyConverter : eigen_from_py_converter_impl<EigenType> {};
 
 template <typename MatType>
-struct eigen_from_py_converter_impl<MatType, Eigen::MatrixBase<MatType> > {
+struct eigen_from_py_converter_impl<MatType, Eigen::MatrixBase<MatType>> {
   static void registration() {
     EigenFromPy<MatType>::registration();
 
@@ -452,7 +452,7 @@ struct eigen_from_py_converter_impl<MatType, Eigen::MatrixBase<MatType> > {
 };
 
 template <typename MatType>
-struct EigenFromPy<Eigen::MatrixBase<MatType> > : EigenFromPy<MatType> {
+struct EigenFromPy<Eigen::MatrixBase<MatType>> : EigenFromPy<MatType> {
   typedef EigenFromPy<MatType> EigenFromPyDerived;
   typedef Eigen::MatrixBase<MatType> Base;
 
@@ -487,7 +487,7 @@ struct EigenFromPy<Eigen::EigenBase<MatType>, typename MatType::Scalar>
 };
 
 template <typename MatType>
-struct EigenFromPy<Eigen::PlainObjectBase<MatType> > : EigenFromPy<MatType> {
+struct EigenFromPy<Eigen::PlainObjectBase<MatType>> : EigenFromPy<MatType> {
   typedef EigenFromPy<MatType> EigenFromPyDerived;
   typedef Eigen::PlainObjectBase<MatType> Base;
 
@@ -506,7 +506,7 @@ struct EigenFromPy<Eigen::PlainObjectBase<MatType> > : EigenFromPy<MatType> {
 #if EIGEN_VERSION_AT_LEAST(3, 2, 0)
 
 template <typename MatType, int Options, typename Stride>
-struct EigenFromPy<Eigen::Ref<MatType, Options, Stride> > {
+struct EigenFromPy<Eigen::Ref<MatType, Options, Stride>> {
   typedef Eigen::Ref<MatType, Options, Stride> RefType;
   typedef typename MatType::Scalar Scalar;
 
@@ -531,7 +531,7 @@ struct EigenFromPy<Eigen::Ref<MatType, Options, Stride> > {
 };
 
 template <typename MatType, int Options, typename Stride>
-struct EigenFromPy<const Eigen::Ref<const MatType, Options, Stride> > {
+struct EigenFromPy<const Eigen::Ref<const MatType, Options, Stride>> {
   typedef const Eigen::Ref<const MatType, Options, Stride> ConstRefType;
   typedef typename MatType::Scalar Scalar;
 

--- a/include/eigenpy/eigen-to-python.hpp
+++ b/include/eigenpy/eigen-to-python.hpp
@@ -28,19 +28,19 @@ template <typename MatType>
 struct eigen_to_py_impl_matrix;
 
 template <typename MatType>
-struct eigen_to_py_impl<MatType, Eigen::MatrixBase<MatType> >
+struct eigen_to_py_impl<MatType, Eigen::MatrixBase<MatType>>
     : eigen_to_py_impl_matrix<MatType> {};
 
 template <typename MatType>
-struct eigen_to_py_impl<MatType&, Eigen::MatrixBase<MatType> >
+struct eigen_to_py_impl<MatType&, Eigen::MatrixBase<MatType>>
     : eigen_to_py_impl_matrix<MatType&> {};
 
 template <typename MatType>
-struct eigen_to_py_impl<const MatType, const Eigen::MatrixBase<MatType> >
+struct eigen_to_py_impl<const MatType, const Eigen::MatrixBase<MatType>>
     : eigen_to_py_impl_matrix<const MatType> {};
 
 template <typename MatType>
-struct eigen_to_py_impl<const MatType&, const Eigen::MatrixBase<MatType> >
+struct eigen_to_py_impl<const MatType&, const Eigen::MatrixBase<MatType>>
     : eigen_to_py_impl_matrix<const MatType&> {};
 
 template <typename MatType>
@@ -81,19 +81,19 @@ template <typename MatType>
 struct eigen_to_py_impl_sparse_matrix;
 
 template <typename MatType>
-struct eigen_to_py_impl<MatType, Eigen::SparseMatrixBase<MatType> >
+struct eigen_to_py_impl<MatType, Eigen::SparseMatrixBase<MatType>>
     : eigen_to_py_impl_sparse_matrix<MatType> {};
 
 template <typename MatType>
-struct eigen_to_py_impl<MatType&, Eigen::SparseMatrixBase<MatType> >
+struct eigen_to_py_impl<MatType&, Eigen::SparseMatrixBase<MatType>>
     : eigen_to_py_impl_sparse_matrix<MatType&> {};
 
 template <typename MatType>
-struct eigen_to_py_impl<const MatType, const Eigen::SparseMatrixBase<MatType> >
+struct eigen_to_py_impl<const MatType, const Eigen::SparseMatrixBase<MatType>>
     : eigen_to_py_impl_sparse_matrix<const MatType> {};
 
 template <typename MatType>
-struct eigen_to_py_impl<const MatType&, const Eigen::SparseMatrixBase<MatType> >
+struct eigen_to_py_impl<const MatType&, const Eigen::SparseMatrixBase<MatType>>
     : eigen_to_py_impl_sparse_matrix<const MatType&> {};
 
 template <typename MatType>
@@ -124,11 +124,11 @@ template <typename TensorType>
 struct eigen_to_py_impl_tensor;
 
 template <typename TensorType>
-struct eigen_to_py_impl<TensorType, Eigen::TensorBase<TensorType> >
+struct eigen_to_py_impl<TensorType, Eigen::TensorBase<TensorType>>
     : eigen_to_py_impl_tensor<TensorType> {};
 
 template <typename TensorType>
-struct eigen_to_py_impl<const TensorType, const Eigen::TensorBase<TensorType> >
+struct eigen_to_py_impl<const TensorType, const Eigen::TensorBase<TensorType>>
     : eigen_to_py_impl_tensor<const TensorType> {};
 
 template <typename TensorType>

--- a/include/eigenpy/eigen/EigenBase.hpp
+++ b/include/eigenpy/eigen/EigenBase.hpp
@@ -11,7 +11,7 @@ namespace eigenpy {
 
 template <typename Derived>
 struct EigenBaseVisitor
-    : public boost::python::def_visitor<EigenBaseVisitor<Derived> > {
+    : public boost::python::def_visitor<EigenBaseVisitor<Derived>> {
   template <class PyClass>
   void visit(PyClass &cl) const {
     cl.def("cols", &Derived::cols, bp::arg("self"),

--- a/include/eigenpy/eigenpy.hpp
+++ b/include/eigenpy/eigenpy.hpp
@@ -66,9 +66,9 @@ EIGEN_DONT_INLINE void exposeType() {
   exposeType<Scalar, 0>();
 
 #ifdef EIGENPY_WITH_TENSOR_SUPPORT
-  enableEigenPySpecific<Eigen::Tensor<Scalar, 1> >();
-  enableEigenPySpecific<Eigen::Tensor<Scalar, 2> >();
-  enableEigenPySpecific<Eigen::Tensor<Scalar, 3> >();
+  enableEigenPySpecific<Eigen::Tensor<Scalar, 1>>();
+  enableEigenPySpecific<Eigen::Tensor<Scalar, 2>>();
+  enableEigenPySpecific<Eigen::Tensor<Scalar, 3>>();
 #endif
 }
 

--- a/include/eigenpy/fwd.hpp
+++ b/include/eigenpy/fwd.hpp
@@ -169,14 +169,14 @@ template <typename EigenType>
 struct get_eigen_plain_type;
 
 template <typename MatType, int Options, typename Stride>
-struct get_eigen_plain_type<Eigen::Ref<MatType, Options, Stride> > {
+struct get_eigen_plain_type<Eigen::Ref<MatType, Options, Stride>> {
   typedef typename Eigen::internal::traits<
-      Eigen::Ref<MatType, Options, Stride> >::PlainObjectType type;
+      Eigen::Ref<MatType, Options, Stride>>::PlainObjectType type;
 };
 
 #ifdef EIGENPY_WITH_TENSOR_SUPPORT
 template <typename TensorType>
-struct get_eigen_plain_type<Eigen::TensorRef<TensorType> > {
+struct get_eigen_plain_type<Eigen::TensorRef<TensorType>> {
   typedef TensorType type;
 };
 #endif

--- a/include/eigenpy/id.hpp
+++ b/include/eigenpy/id.hpp
@@ -15,7 +15,7 @@ namespace eigenpy {
 /// exposed with Boost.Python
 ///
 template <class C>
-struct IdVisitor : public bp::def_visitor<IdVisitor<C> > {
+struct IdVisitor : public bp::def_visitor<IdVisitor<C>> {
   template <class PyClass>
   void visit(PyClass& cl) const {
     cl.def("id", &id, bp::arg("self"),

--- a/include/eigenpy/map.hpp
+++ b/include/eigenpy/map.hpp
@@ -23,7 +23,7 @@ namespace eigenpy {
 template <typename Container>
 struct overload_base_get_item_for_map
     : public boost::python::def_visitor<
-          overload_base_get_item_for_map<Container> > {
+          overload_base_get_item_for_map<Container>> {
   typedef typename Container::value_type value_type;
   typedef typename Container::value_type::second_type data_type;
   typedef typename Container::key_type key_type;
@@ -165,9 +165,8 @@ struct dict_to_map {
 /// and set_item() using emplace().
 template <class Container, bool NoProxy>
 struct emplace_set_derived_policies
-    : bp::map_indexing_suite<
-          Container, NoProxy,
-          emplace_set_derived_policies<Container, NoProxy> > {
+    : bp::map_indexing_suite<Container, NoProxy,
+                             emplace_set_derived_policies<Container, NoProxy>> {
   typedef typename Container::key_type index_type;
   typedef typename Container::value_type::second_type data_type;
   typedef typename Container::value_type value_type;
@@ -185,7 +184,7 @@ struct emplace_set_derived_policies
     namespace mpl = boost::mpl;
 
     typedef typename mpl::if_<
-        mpl::and_<boost::is_class<data_type>, mpl::bool_<!NoProxy> >,
+        mpl::and_<boost::is_class<data_type>, mpl::bool_<!NoProxy>>,
         bp::return_internal_reference<>, bp::default_call_policies>::type
         get_data_return_policy;
 

--- a/include/eigenpy/numpy-allocator.hpp
+++ b/include/eigenpy/numpy-allocator.hpp
@@ -20,13 +20,13 @@ struct numpy_allocator_impl_matrix;
 
 template <typename MatType>
 struct numpy_allocator_impl<
-    MatType, Eigen::MatrixBase<typename remove_const_reference<MatType>::type> >
+    MatType, Eigen::MatrixBase<typename remove_const_reference<MatType>::type>>
     : numpy_allocator_impl_matrix<MatType> {};
 
 template <typename MatType>
 struct numpy_allocator_impl<
     const MatType,
-    const Eigen::MatrixBase<typename remove_const_reference<MatType>::type> >
+    const Eigen::MatrixBase<typename remove_const_reference<MatType>::type>>
     : numpy_allocator_impl_matrix<const MatType> {};
 
 // template <typename MatType>
@@ -35,7 +35,7 @@ struct numpy_allocator_impl<
 //{};
 
 template <typename MatType>
-struct numpy_allocator_impl<const MatType &, const Eigen::MatrixBase<MatType> >
+struct numpy_allocator_impl<const MatType &, const Eigen::MatrixBase<MatType>>
     : numpy_allocator_impl_matrix<const MatType &> {};
 
 template <typename EigenType,
@@ -67,12 +67,12 @@ template <typename TensorType>
 struct numpy_allocator_impl_tensor;
 
 template <typename TensorType>
-struct numpy_allocator_impl<TensorType, Eigen::TensorBase<TensorType> >
+struct numpy_allocator_impl<TensorType, Eigen::TensorBase<TensorType>>
     : numpy_allocator_impl_tensor<TensorType> {};
 
 template <typename TensorType>
 struct numpy_allocator_impl<const TensorType,
-                            const Eigen::TensorBase<TensorType> >
+                            const Eigen::TensorBase<TensorType>>
     : numpy_allocator_impl_tensor<const TensorType> {};
 
 template <typename TensorType>
@@ -120,7 +120,7 @@ struct numpy_allocator_impl_matrix<MatType &> {
 #if EIGEN_VERSION_AT_LEAST(3, 2, 0)
 
 template <typename MatType, int Options, typename Stride>
-struct numpy_allocator_impl_matrix<Eigen::Ref<MatType, Options, Stride> > {
+struct numpy_allocator_impl_matrix<Eigen::Ref<MatType, Options, Stride>> {
   typedef Eigen::Ref<MatType, Options, Stride> RefType;
 
   static PyArrayObject *allocate(RefType &mat, npy_intp nd, npy_intp *shape) {
@@ -190,7 +190,7 @@ struct numpy_allocator_impl_matrix<const MatType &> {
 
 template <typename MatType, int Options, typename Stride>
 struct numpy_allocator_impl_matrix<
-    const Eigen::Ref<const MatType, Options, Stride> > {
+    const Eigen::Ref<const MatType, Options, Stride>> {
   typedef const Eigen::Ref<const MatType, Options, Stride> RefType;
 
   static PyArrayObject *allocate(RefType &mat, npy_intp nd, npy_intp *shape) {
@@ -233,7 +233,7 @@ struct numpy_allocator_impl_matrix<
 
 #ifdef EIGENPY_WITH_TENSOR_SUPPORT
 template <typename TensorType>
-struct numpy_allocator_impl_tensor<Eigen::TensorRef<TensorType> > {
+struct numpy_allocator_impl_tensor<Eigen::TensorRef<TensorType>> {
   typedef Eigen::TensorRef<TensorType> RefType;
 
   static PyArrayObject *allocate(RefType &tensor, npy_intp nd,
@@ -266,7 +266,7 @@ struct numpy_allocator_impl_tensor<Eigen::TensorRef<TensorType> > {
 };
 
 template <typename TensorType>
-struct numpy_allocator_impl_tensor<const Eigen::TensorRef<const TensorType> > {
+struct numpy_allocator_impl_tensor<const Eigen::TensorRef<const TensorType>> {
   typedef const Eigen::TensorRef<const TensorType> RefType;
 
   static PyArrayObject *allocate(RefType &tensor, npy_intp nd,

--- a/include/eigenpy/numpy-map.hpp
+++ b/include/eigenpy/numpy-map.hpp
@@ -24,13 +24,13 @@ struct numpy_map_impl;
 template <typename MatType, typename InputScalar, int AlignmentValue,
           typename Stride>
 struct numpy_map_impl<MatType, InputScalar, AlignmentValue, Stride,
-                      Eigen::MatrixBase<MatType> >
+                      Eigen::MatrixBase<MatType>>
     : numpy_map_impl_matrix<MatType, InputScalar, AlignmentValue, Stride> {};
 
 template <typename MatType, typename InputScalar, int AlignmentValue,
           typename Stride>
 struct numpy_map_impl<const MatType, InputScalar, AlignmentValue, Stride,
-                      const Eigen::MatrixBase<MatType> >
+                      const Eigen::MatrixBase<MatType>>
     : numpy_map_impl_matrix<const MatType, InputScalar, AlignmentValue,
                             Stride> {};
 
@@ -183,13 +183,13 @@ struct numpy_map_impl_tensor;
 template <typename TensorType, typename InputScalar, int AlignmentValue,
           typename Stride>
 struct numpy_map_impl<TensorType, InputScalar, AlignmentValue, Stride,
-                      Eigen::TensorBase<TensorType> >
+                      Eigen::TensorBase<TensorType>>
     : numpy_map_impl_tensor<TensorType, InputScalar, AlignmentValue, Stride> {};
 
 template <typename TensorType, typename InputScalar, int AlignmentValue,
           typename Stride>
 struct numpy_map_impl<const TensorType, InputScalar, AlignmentValue, Stride,
-                      const Eigen::TensorBase<TensorType> >
+                      const Eigen::TensorBase<TensorType>>
     : numpy_map_impl_tensor<const TensorType, InputScalar, AlignmentValue,
                             Stride> {};
 

--- a/include/eigenpy/numpy.hpp
+++ b/include/eigenpy/numpy.hpp
@@ -187,15 +187,15 @@ struct NumpyEquivalentType<long double> {
 };
 
 template <>
-struct NumpyEquivalentType<std::complex<float> > {
+struct NumpyEquivalentType<std::complex<float>> {
   enum { type_code = NPY_CFLOAT };
 };
 template <>
-struct NumpyEquivalentType<std::complex<double> > {
+struct NumpyEquivalentType<std::complex<double>> {
   enum { type_code = NPY_CDOUBLE };
 };
 template <>
-struct NumpyEquivalentType<std::complex<long double> > {
+struct NumpyEquivalentType<std::complex<long double>> {
   enum { type_code = NPY_CLONGDOUBLE };
 };
 

--- a/include/eigenpy/optional.hpp
+++ b/include/eigenpy/optional.hpp
@@ -25,12 +25,12 @@ namespace python {
 namespace converter {
 
 template <typename T>
-struct expected_pytype_for_arg<boost::optional<T> >
+struct expected_pytype_for_arg<boost::optional<T>>
     : expected_pytype_for_arg<T> {};
 
 #ifdef EIGENPY_WITH_CXX17_SUPPORT
 template <typename T>
-struct expected_pytype_for_arg<std::optional<T> > : expected_pytype_for_arg<T> {
+struct expected_pytype_for_arg<std::optional<T>> : expected_pytype_for_arg<T> {
 };
 #endif
 
@@ -88,7 +88,7 @@ struct OptionalToPython {
   }
 
   static void registration() {
-    if (!check_registration<OptionalTpl<T> >()) {
+    if (!check_registration<OptionalTpl<T>>()) {
       bp::to_python_converter<OptionalTpl<T>, OptionalToPython, true>();
     }
   }
@@ -122,7 +122,7 @@ void OptionalFromPython<T, OptionalTpl>::construct(
     PyObject *obj_ptr, bp::converter::rvalue_from_python_stage1_data *memory) {
   // create storage
   using rvalue_storage_t =
-      bp::converter::rvalue_from_python_storage<OptionalTpl<T> >;
+      bp::converter::rvalue_from_python_storage<OptionalTpl<T>>;
   void *storage =
       reinterpret_cast<rvalue_storage_t *>(reinterpret_cast<void *>(memory))
           ->storage.bytes;
@@ -140,8 +140,8 @@ void OptionalFromPython<T, OptionalTpl>::construct(
 template <typename T, template <typename> class OptionalTpl>
 void OptionalFromPython<T, OptionalTpl>::registration() {
   bp::converter::registry::push_back(
-      &convertible, &construct, bp::type_id<OptionalTpl<T> >(),
-      bp::converter::expected_pytype_for_arg<OptionalTpl<T> >::get_pytype);
+      &convertible, &construct, bp::type_id<OptionalTpl<T>>(),
+      bp::converter::expected_pytype_for_arg<OptionalTpl<T>>::get_pytype);
 }
 
 }  // namespace detail

--- a/include/eigenpy/quaternion.hpp
+++ b/include/eigenpy/quaternion.hpp
@@ -21,7 +21,7 @@ struct rvalue_from_python_data<Eigen::QuaternionBase<Quaternion> const&>
 };
 
 template <class Quaternion>
-struct implicit<Quaternion, Eigen::QuaternionBase<Quaternion> > {
+struct implicit<Quaternion, Eigen::QuaternionBase<Quaternion>> {
   typedef Quaternion Source;
   typedef Eigen::QuaternionBase<Quaternion> Target;
 
@@ -69,7 +69,7 @@ template <typename QuaternionDerived>
 class QuaternionVisitor;
 
 template <typename Scalar, int Options>
-struct call<Eigen::Quaternion<Scalar, Options> > {
+struct call<Eigen::Quaternion<Scalar, Options>> {
   typedef Eigen::Quaternion<Scalar, Options> Quaternion;
   static inline void expose() { QuaternionVisitor<Quaternion>::expose(); }
 
@@ -82,7 +82,7 @@ struct call<Eigen::Quaternion<Scalar, Options> > {
 
 template <typename Quaternion>
 class QuaternionVisitor
-    : public bp::def_visitor<QuaternionVisitor<Quaternion> > {
+    : public bp::def_visitor<QuaternionVisitor<Quaternion>> {
   typedef Eigen::QuaternionBase<Quaternion> QuaternionBase;
 
   typedef typename QuaternionBase::Scalar Scalar;

--- a/include/eigenpy/scalar-conversion.hpp
+++ b/include/eigenpy/scalar-conversion.hpp
@@ -20,7 +20,7 @@ struct FromTypeToType
 
 /// FromTypeToType specialization to manage std::complex
 template <typename ScalarSource, typename ScalarTarget>
-struct FromTypeToType<std::complex<ScalarSource>, std::complex<ScalarTarget> >
+struct FromTypeToType<std::complex<ScalarSource>, std::complex<ScalarTarget>>
     : public boost::mpl::if_c<
           std::is_same<ScalarSource, ScalarTarget>::value, std::true_type,
           typename boost::numeric::conversion_traits<

--- a/include/eigenpy/scipy-allocator.hpp
+++ b/include/eigenpy/scipy-allocator.hpp
@@ -21,13 +21,13 @@ struct scipy_allocator_impl_sparse_matrix;
 template <typename MatType>
 struct scipy_allocator_impl<
     MatType,
-    Eigen::SparseMatrixBase<typename remove_const_reference<MatType>::type> >
+    Eigen::SparseMatrixBase<typename remove_const_reference<MatType>::type>>
     : scipy_allocator_impl_sparse_matrix<MatType> {};
 
 template <typename MatType>
-struct scipy_allocator_impl<
-    const MatType, const Eigen::SparseMatrixBase<
-                       typename remove_const_reference<MatType>::type> >
+struct scipy_allocator_impl<const MatType,
+                            const Eigen::SparseMatrixBase<
+                                typename remove_const_reference<MatType>::type>>
     : scipy_allocator_impl_sparse_matrix<const MatType> {};
 
 // template <typename MatType>
@@ -37,7 +37,7 @@ struct scipy_allocator_impl<
 
 template <typename MatType>
 struct scipy_allocator_impl<const MatType &,
-                            const Eigen::SparseMatrixBase<MatType> >
+                            const Eigen::SparseMatrixBase<MatType>>
     : scipy_allocator_impl_sparse_matrix<const MatType &> {};
 
 template <typename EigenType,

--- a/include/eigenpy/solvers/BFGSPreconditioners.hpp
+++ b/include/eigenpy/solvers/BFGSPreconditioners.hpp
@@ -15,7 +15,7 @@ namespace eigenpy {
 
 template <typename Preconditioner>
 struct BFGSPreconditionerBaseVisitor
-    : public bp::def_visitor<BFGSPreconditionerBaseVisitor<Preconditioner> > {
+    : public bp::def_visitor<BFGSPreconditionerBaseVisitor<Preconditioner>> {
   typedef Eigen::VectorXd VectorType;
   template <class PyClass>
   void visit(PyClass& cl) const {
@@ -46,7 +46,7 @@ struct BFGSPreconditionerBaseVisitor
 template <typename Preconditioner>
 struct LimitedBFGSPreconditionerBaseVisitor
     : public bp::def_visitor<
-          LimitedBFGSPreconditionerBaseVisitor<Preconditioner> > {
+          LimitedBFGSPreconditionerBaseVisitor<Preconditioner>> {
   template <class PyClass>
   void visit(PyClass& cl) const {
     cl.def(PreconditionerBaseVisitor<Preconditioner>())

--- a/include/eigenpy/solvers/BasicPreconditioners.hpp
+++ b/include/eigenpy/solvers/BasicPreconditioners.hpp
@@ -14,7 +14,7 @@ namespace eigenpy {
 
 template <typename Preconditioner>
 struct PreconditionerBaseVisitor
-    : public bp::def_visitor<PreconditionerBaseVisitor<Preconditioner> > {
+    : public bp::def_visitor<PreconditionerBaseVisitor<Preconditioner>> {
   typedef Eigen::MatrixXd MatrixType;
   typedef Eigen::VectorXd VectorType;
 
@@ -51,7 +51,7 @@ struct PreconditionerBaseVisitor
 
 template <typename Scalar>
 struct DiagonalPreconditionerVisitor
-    : PreconditionerBaseVisitor<Eigen::DiagonalPreconditioner<Scalar> > {
+    : PreconditionerBaseVisitor<Eigen::DiagonalPreconditioner<Scalar>> {
   typedef Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> MatrixType;
   typedef Eigen::DiagonalPreconditioner<Scalar> Preconditioner;
 
@@ -79,7 +79,7 @@ struct DiagonalPreconditionerVisitor
 template <typename Scalar>
 struct LeastSquareDiagonalPreconditionerVisitor
     : PreconditionerBaseVisitor<
-          Eigen::LeastSquareDiagonalPreconditioner<Scalar> > {
+          Eigen::LeastSquareDiagonalPreconditioner<Scalar>> {
   typedef Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> MatrixType;
   typedef Eigen::LeastSquareDiagonalPreconditioner<Scalar> Preconditioner;
 

--- a/include/eigenpy/solvers/ConjugateGradient.hpp
+++ b/include/eigenpy/solvers/ConjugateGradient.hpp
@@ -15,7 +15,7 @@ namespace eigenpy {
 template <typename ConjugateGradient>
 struct ConjugateGradientVisitor
     : public boost::python::def_visitor<
-          ConjugateGradientVisitor<ConjugateGradient> > {
+          ConjugateGradientVisitor<ConjugateGradient>> {
   typedef typename ConjugateGradient::MatrixType MatrixType;
 
   template <class PyClass>

--- a/include/eigenpy/solvers/IterativeSolverBase.hpp
+++ b/include/eigenpy/solvers/IterativeSolverBase.hpp
@@ -12,7 +12,7 @@ namespace eigenpy {
 
 template <typename IterativeSolver>
 struct IterativeSolverVisitor : public boost::python::def_visitor<
-                                    IterativeSolverVisitor<IterativeSolver> > {
+                                    IterativeSolverVisitor<IterativeSolver>> {
   typedef typename IterativeSolver::MatrixType MatrixType;
   typedef typename IterativeSolver::Preconditioner Preconditioner;
   typedef Eigen::VectorXd VectorType;

--- a/include/eigenpy/solvers/LeastSquaresConjugateGradient.hpp
+++ b/include/eigenpy/solvers/LeastSquaresConjugateGradient.hpp
@@ -14,8 +14,8 @@ namespace eigenpy {
 
 template <typename LeastSquaresConjugateGradient>
 struct LeastSquaresConjugateGradientVisitor
-    : public boost::python::def_visitor<LeastSquaresConjugateGradientVisitor<
-          LeastSquaresConjugateGradient> > {
+    : public boost::python::def_visitor<
+          LeastSquaresConjugateGradientVisitor<LeastSquaresConjugateGradient>> {
   typedef Eigen::MatrixXd MatrixType;
 
   template <class PyClass>

--- a/include/eigenpy/solvers/SparseSolverBase.hpp
+++ b/include/eigenpy/solvers/SparseSolverBase.hpp
@@ -11,7 +11,7 @@ namespace eigenpy {
 
 template <typename SparseSolver>
 struct SparseSolverVisitor
-    : public bp::def_visitor<SparseSolverVisitor<SparseSolver> > {
+    : public bp::def_visitor<SparseSolverVisitor<SparseSolver>> {
   typedef Eigen::VectorXd VectorType;
 
   template <class PyClass>

--- a/include/eigenpy/sparse/eigen-from-python.hpp
+++ b/include/eigenpy/sparse/eigen-from-python.hpp
@@ -14,7 +14,7 @@ namespace eigenpy {
 
 template <typename SparseMatrixType>
 struct expected_pytype_for_arg<SparseMatrixType,
-                               Eigen::SparseMatrixBase<SparseMatrixType> > {
+                               Eigen::SparseMatrixBase<SparseMatrixType>> {
   static PyTypeObject const *get_pytype() {
     PyTypeObject const *py_type = ScipyType::get_pytype<SparseMatrixType>();
     return py_type;
@@ -29,9 +29,9 @@ namespace converter {
 
 template <typename Scalar, int Options, typename StorageIndex>
 struct expected_pytype_for_arg<
-    Eigen::SparseMatrix<Scalar, Options, StorageIndex> >
+    Eigen::SparseMatrix<Scalar, Options, StorageIndex>>
     : eigenpy::expected_pytype_for_arg<
-          Eigen::SparseMatrix<Scalar, Options, StorageIndex> > {};
+          Eigen::SparseMatrix<Scalar, Options, StorageIndex>> {};
 
 template <typename Scalar, int Options, typename StorageIndex>
 struct rvalue_from_python_data<
@@ -78,7 +78,7 @@ namespace eigenpy {
 
 template <typename SparseMatrixType>
 struct eigen_from_py_impl<SparseMatrixType,
-                          Eigen::SparseMatrixBase<SparseMatrixType> > {
+                          Eigen::SparseMatrixBase<SparseMatrixType>> {
   typedef typename SparseMatrixType::Scalar Scalar;
 
   /// \brief Determine if pyObj can be converted into a MatType object
@@ -94,7 +94,7 @@ struct eigen_from_py_impl<SparseMatrixType,
 template <typename SparseMatrixType>
 void *eigen_from_py_impl<
     SparseMatrixType,
-    Eigen::SparseMatrixBase<SparseMatrixType> >::convertible(PyObject *pyObj) {
+    Eigen::SparseMatrixBase<SparseMatrixType>>::convertible(PyObject *pyObj) {
   const PyTypeObject *type = Py_TYPE(pyObj);
   const PyTypeObject *sparse_matrix_py_type =
       ScipyType::get_pytype<SparseMatrixType>();
@@ -168,7 +168,7 @@ void eigen_sparse_matrix_from_py_construct(
 
 template <typename SparseMatrixType>
 void eigen_from_py_impl<SparseMatrixType,
-                        Eigen::SparseMatrixBase<SparseMatrixType> >::
+                        Eigen::SparseMatrixBase<SparseMatrixType>>::
     construct(PyObject *pyObj,
               bp::converter::rvalue_from_python_stage1_data *memory) {
   eigen_sparse_matrix_from_py_construct<SparseMatrixType>(pyObj, memory);
@@ -177,7 +177,7 @@ void eigen_from_py_impl<SparseMatrixType,
 template <typename SparseMatrixType>
 void eigen_from_py_impl<
     SparseMatrixType,
-    Eigen::SparseMatrixBase<SparseMatrixType> >::registration() {
+    Eigen::SparseMatrixBase<SparseMatrixType>>::registration() {
   bp::converter::registry::push_back(
       reinterpret_cast<void *(*)(_object *)>(&eigen_from_py_impl::convertible),
       &eigen_from_py_impl::construct, bp::type_id<SparseMatrixType>()
@@ -189,8 +189,8 @@ void eigen_from_py_impl<
 }
 
 template <typename SparseMatrixType>
-struct eigen_from_py_converter_impl<
-    SparseMatrixType, Eigen::SparseMatrixBase<SparseMatrixType> > {
+struct eigen_from_py_converter_impl<SparseMatrixType,
+                                    Eigen::SparseMatrixBase<SparseMatrixType>> {
   static void registration() {
     EigenFromPy<SparseMatrixType>::registration();
 
@@ -209,7 +209,7 @@ struct eigen_from_py_converter_impl<
 };
 
 template <typename SparseMatrixType>
-struct EigenFromPy<Eigen::SparseMatrixBase<SparseMatrixType> >
+struct EigenFromPy<Eigen::SparseMatrixBase<SparseMatrixType>>
     : EigenFromPy<SparseMatrixType> {
   typedef EigenFromPy<SparseMatrixType> EigenFromPyDerived;
   typedef Eigen::SparseMatrixBase<SparseMatrixType> Base;

--- a/include/eigenpy/std-array.hpp
+++ b/include/eigenpy/std-array.hpp
@@ -21,13 +21,13 @@ template <typename Container, bool NoProxy, class SliceAllocator>
 class final_array_derived_policies
     : public array_indexing_suite<
           Container, NoProxy, SliceAllocator,
-          final_array_derived_policies<Container, NoProxy, SliceAllocator> > {};
+          final_array_derived_policies<Container, NoProxy, SliceAllocator>> {};
 }  // namespace details
 
 template <typename Container, bool NoProxy = false,
           class SliceAllocator = std::allocator<typename Container::value_type>,
           class DerivedPolicies = details::final_array_derived_policies<
-              Container, NoProxy, SliceAllocator> >
+              Container, NoProxy, SliceAllocator>>
 class array_indexing_suite
     : public bp::vector_indexing_suite<Container, NoProxy, DerivedPolicies> {
  public:
@@ -108,7 +108,7 @@ class array_indexing_suite
 /// std::vector (dynamic size).
 template <typename array_type, bool NoProxy = false,
           class SliceAllocator =
-              std::allocator<typename array_type::value_type> >
+              std::allocator<typename array_type::value_type>>
 struct StdArrayPythonVisitor {
   typedef typename array_type::value_type value_type;
 
@@ -155,7 +155,7 @@ void exposeStdArrayEigenSpecificType(const char *name) {
   oss << Size << "_" << name;
   typedef std::array<MatrixType, Size> array_type;
   StdArrayPythonVisitor<array_type, false,
-                        Eigen::aligned_allocator<MatrixType> >::
+                        Eigen::aligned_allocator<MatrixType>>::
       expose(oss.str(),
              details::overload_base_get_item_for_std_vector<array_type>());
 }

--- a/include/eigenpy/std-map.hpp
+++ b/include/eigenpy/std-map.hpp
@@ -30,7 +30,7 @@ using ::eigenpy::overload_base_get_item_for_std_map;
  * returned to Python.
  */
 template <class Key, class T, class Compare = std::less<Key>,
-          class Allocator = std::allocator<std::pair<const Key, T> >,
+          class Allocator = std::allocator<std::pair<const Key, T>>,
           bool NoProxy = false>
 struct StdMapPythonVisitor
     : GenericMapVisitor<std::map<Key, T, Compare, Allocator>, NoProxy> {};

--- a/include/eigenpy/std-unique-ptr.hpp
+++ b/include/eigenpy/std-unique-ptr.hpp
@@ -137,7 +137,7 @@ namespace python {
 template <typename T>
 struct to_python_value<const std::unique_ptr<T>&>
     : eigenpy::details::StdUniquePtrResultConverter::apply<
-          std::unique_ptr<T> >::type {};
+          std::unique_ptr<T>>::type {};
 
 }  // namespace python
 }  // namespace boost

--- a/include/eigenpy/std-vector.hpp
+++ b/include/eigenpy/std-vector.hpp
@@ -77,7 +77,7 @@ struct build_list<vector_type, true> {
 template <typename Container>
 struct overload_base_get_item_for_std_vector
     : public boost::python::def_visitor<
-          overload_base_get_item_for_std_vector<Container> > {
+          overload_base_get_item_for_std_vector<Container>> {
   typedef typename Container::value_type value_type;
   typedef typename Container::value_type data_type;
   typedef size_t index_type;
@@ -129,7 +129,7 @@ namespace python {
 
 template <typename MatrixType>
 struct extract_to_eigen_ref
-    : converter::extract_rvalue<Eigen::Ref<MatrixType> > {
+    : converter::extract_rvalue<Eigen::Ref<MatrixType>> {
   typedef Eigen::Ref<MatrixType> RefType;
 
  protected:
@@ -150,7 +150,7 @@ template <typename Scalar, int Rows, int Cols, int Options, int MaxRows,
           int MaxCols>
 struct extract<Eigen::Matrix<Scalar, Rows, Cols, Options, MaxRows, MaxCols> &>
     : extract_to_eigen_ref<
-          Eigen::Matrix<Scalar, Rows, Cols, Options, MaxRows, MaxCols> > {
+          Eigen::Matrix<Scalar, Rows, Cols, Options, MaxRows, MaxCols>> {
   typedef Eigen::Matrix<Scalar, Rows, Cols, Options, MaxRows, MaxCols>
       MatrixType;
   typedef extract_to_eigen_ref<MatrixType> base;
@@ -160,7 +160,7 @@ struct extract<Eigen::Matrix<Scalar, Rows, Cols, Options, MaxRows, MaxCols> &>
 
 template <typename Derived>
 struct extract<Eigen::MatrixBase<Derived> &>
-    : extract_to_eigen_ref<Eigen::MatrixBase<Derived> > {
+    : extract_to_eigen_ref<Eigen::MatrixBase<Derived>> {
   typedef Eigen::MatrixBase<Derived> MatrixType;
   typedef extract_to_eigen_ref<MatrixType> base;
   extract(PyObject *o) : base(o) {}
@@ -169,7 +169,7 @@ struct extract<Eigen::MatrixBase<Derived> &>
 
 template <typename Derived>
 struct extract<Eigen::RefBase<Derived> &>
-    : extract_to_eigen_ref<Eigen::RefBase<Derived> > {
+    : extract_to_eigen_ref<Eigen::RefBase<Derived>> {
   typedef Eigen::RefBase<Derived> MatrixType;
   typedef extract_to_eigen_ref<MatrixType> base;
   extract(PyObject *o) : base(o) {}
@@ -247,7 +247,7 @@ struct container_traits {
 };
 
 template <typename _Tp, std::size_t Size>
-struct container_traits<std::array<_Tp, Size> > {
+struct container_traits<std::array<_Tp, Size>> {
   typedef void Allocator;
 };
 };  // namespace details
@@ -322,7 +322,7 @@ namespace internal {
 
 template <typename T,
           bool has_operator_equal_value =
-              std::is_base_of<std::true_type, has_operator_equal<T> >::value>
+              std::is_base_of<std::true_type, has_operator_equal<T>>::value>
 struct contains_algo;
 
 template <typename T>
@@ -349,7 +349,7 @@ template <class Container, bool NoProxy>
 struct contains_vector_derived_policies
     : public ::boost::python::vector_indexing_suite<
           Container, NoProxy,
-          contains_vector_derived_policies<Container, NoProxy> > {
+          contains_vector_derived_policies<Container, NoProxy>> {
   typedef typename Container::value_type key_type;
 
   static bool contains(Container &container, key_type const &key) {
@@ -365,7 +365,7 @@ struct contains_vector_derived_policies
 template <typename Container, bool NoProxy, typename CoVisitor>
 struct ExposeStdMethodToStdVector
     : public boost::python::def_visitor<
-          ExposeStdMethodToStdVector<Container, NoProxy, CoVisitor> > {
+          ExposeStdMethodToStdVector<Container, NoProxy, CoVisitor>> {
   typedef StdContainerFromPythonList<Container, NoProxy>
       FromPythonListConverter;
 
@@ -454,7 +454,7 @@ struct StdVectorPythonVisitor {
       // Standard vector indexing definition
       boost::python::vector_indexing_suite<
           vector_type, NoProxy,
-          internal::contains_vector_derived_policies<vector_type, NoProxy> >
+          internal::contains_vector_derived_policies<vector_type, NoProxy>>
           vector_indexing;
 
       cl.def(bp::init<size_t, const value_type &>(
@@ -480,7 +480,7 @@ struct StdVectorPythonVisitor {
  */
 void EIGENPY_DLLAPI exposeStdVector();
 
-template <typename MatType, typename Alloc = Eigen::aligned_allocator<MatType> >
+template <typename MatType, typename Alloc = Eigen::aligned_allocator<MatType>>
 void exposeStdVectorEigenSpecificType(const char *name) {
   typedef std::vector<MatType, Alloc> VecMatType;
   std::string full_name = "StdVec_";

--- a/include/eigenpy/stride.hpp
+++ b/include/eigenpy/stride.hpp
@@ -27,7 +27,7 @@ struct stride_type;
 
 template <typename MatrixType, int InnerStride, int OuterStride>
 struct stride_type<MatrixType, InnerStride, OuterStride,
-                   Eigen::MatrixBase<MatrixType> > {
+                   Eigen::MatrixBase<MatrixType>> {
   typedef
       typename stride_type_matrix<MatrixType, InnerStride, OuterStride>::type
           type;
@@ -35,7 +35,7 @@ struct stride_type<MatrixType, InnerStride, OuterStride,
 
 template <typename MatrixType, int InnerStride, int OuterStride>
 struct stride_type<const MatrixType, InnerStride, OuterStride,
-                   const Eigen::MatrixBase<MatrixType> > {
+                   const Eigen::MatrixBase<MatrixType>> {
   typedef typename stride_type_matrix<const MatrixType, InnerStride,
                                       OuterStride>::type type;
 };
@@ -43,13 +43,13 @@ struct stride_type<const MatrixType, InnerStride, OuterStride,
 #ifdef EIGENPY_WITH_TENSOR_SUPPORT
 template <typename TensorType, int InnerStride, int OuterStride>
 struct stride_type<TensorType, InnerStride, OuterStride,
-                   Eigen::TensorBase<TensorType> > {
+                   Eigen::TensorBase<TensorType>> {
   typedef Eigen::Stride<OuterStride, InnerStride> type;
 };
 
 template <typename TensorType, int InnerStride, int OuterStride>
 struct stride_type<const TensorType, InnerStride, OuterStride,
-                   const Eigen::TensorBase<TensorType> > {
+                   const Eigen::TensorBase<TensorType>> {
   typedef Eigen::Stride<OuterStride, InnerStride> type;
 };
 #endif

--- a/include/eigenpy/tensor/eigen-from-python.hpp
+++ b/include/eigenpy/tensor/eigen-from-python.hpp
@@ -13,7 +13,7 @@
 namespace eigenpy {
 
 template <typename TensorType>
-struct expected_pytype_for_arg<TensorType, Eigen::TensorBase<TensorType> > {
+struct expected_pytype_for_arg<TensorType, Eigen::TensorBase<TensorType>> {
   static PyTypeObject const *get_pytype() {
     PyTypeObject const *py_type = eigenpy::getPyArrayType();
     return py_type;
@@ -27,9 +27,9 @@ namespace python {
 namespace converter {
 
 template <typename Scalar, int Rank, int Options, typename IndexType>
-struct expected_pytype_for_arg<Eigen::Tensor<Scalar, Rank, Options, IndexType> >
+struct expected_pytype_for_arg<Eigen::Tensor<Scalar, Rank, Options, IndexType>>
     : eigenpy::expected_pytype_for_arg<
-          Eigen::Tensor<Scalar, Rank, Options, IndexType> > {};
+          Eigen::Tensor<Scalar, Rank, Options, IndexType>> {};
 
 template <typename Scalar, int Rank, int Options, typename IndexType>
 struct rvalue_from_python_data<
@@ -75,7 +75,7 @@ struct referent_storage<const Eigen::TensorRef<const TensorType> &> {
 namespace eigenpy {
 
 template <typename TensorType>
-struct eigen_from_py_impl<TensorType, Eigen::TensorBase<TensorType> > {
+struct eigen_from_py_impl<TensorType, Eigen::TensorBase<TensorType>> {
   typedef typename TensorType::Scalar Scalar;
 
   /// \brief Determine if pyObj can be converted into a MatType object
@@ -90,7 +90,7 @@ struct eigen_from_py_impl<TensorType, Eigen::TensorBase<TensorType> > {
 
 template <typename TensorType>
 void *
-eigen_from_py_impl<TensorType, Eigen::TensorBase<TensorType> >::convertible(
+eigen_from_py_impl<TensorType, Eigen::TensorBase<TensorType>>::convertible(
     PyObject *pyObj) {
   if (!call_PyArray_Check(reinterpret_cast<PyObject *>(pyObj))) return 0;
 
@@ -119,14 +119,14 @@ eigen_from_py_impl<TensorType, Eigen::TensorBase<TensorType> >::convertible(
 }
 
 template <typename TensorType>
-void eigen_from_py_impl<TensorType, Eigen::TensorBase<TensorType> >::construct(
+void eigen_from_py_impl<TensorType, Eigen::TensorBase<TensorType>>::construct(
     PyObject *pyObj, bp::converter::rvalue_from_python_stage1_data *memory) {
   eigen_from_py_construct<TensorType>(pyObj, memory);
 }
 
 template <typename TensorType>
 void eigen_from_py_impl<TensorType,
-                        Eigen::TensorBase<TensorType> >::registration() {
+                        Eigen::TensorBase<TensorType>>::registration() {
   bp::converter::registry::push_back(
       reinterpret_cast<void *(*)(_object *)>(&eigen_from_py_impl::convertible),
       &eigen_from_py_impl::construct, bp::type_id<TensorType>()
@@ -138,8 +138,7 @@ void eigen_from_py_impl<TensorType,
 }
 
 template <typename TensorType>
-struct eigen_from_py_converter_impl<TensorType,
-                                    Eigen::TensorBase<TensorType> > {
+struct eigen_from_py_converter_impl<TensorType, Eigen::TensorBase<TensorType>> {
   static void registration() {
     EigenFromPy<TensorType>::registration();
 
@@ -158,7 +157,7 @@ struct eigen_from_py_converter_impl<TensorType,
 };
 
 template <typename TensorType>
-struct EigenFromPy<Eigen::TensorBase<TensorType> > : EigenFromPy<TensorType> {
+struct EigenFromPy<Eigen::TensorBase<TensorType>> : EigenFromPy<TensorType> {
   typedef EigenFromPy<TensorType> EigenFromPyDerived;
   typedef Eigen::TensorBase<TensorType> Base;
 
@@ -175,7 +174,7 @@ struct EigenFromPy<Eigen::TensorBase<TensorType> > : EigenFromPy<TensorType> {
 };
 
 template <typename TensorType>
-struct EigenFromPy<Eigen::TensorRef<TensorType> > {
+struct EigenFromPy<Eigen::TensorRef<TensorType>> {
   typedef Eigen::TensorRef<TensorType> RefType;
   typedef typename TensorType::Scalar Scalar;
 
@@ -200,7 +199,7 @@ struct EigenFromPy<Eigen::TensorRef<TensorType> > {
 };
 
 template <typename TensorType>
-struct EigenFromPy<const Eigen::TensorRef<const TensorType> > {
+struct EigenFromPy<const Eigen::TensorRef<const TensorType>> {
   typedef const Eigen::TensorRef<const TensorType> ConstRefType;
   typedef typename TensorType::Scalar Scalar;
 

--- a/include/eigenpy/type_info.hpp
+++ b/include/eigenpy/type_info.hpp
@@ -51,7 +51,7 @@ void expose_std_type_info() {
 /// \brief Add the Python method type_info to query information of a type.
 ///
 template <class C>
-struct TypeInfoVisitor : public bp::def_visitor<TypeInfoVisitor<C> > {
+struct TypeInfoVisitor : public bp::def_visitor<TypeInfoVisitor<C>> {
   template <class PyClass>
   void visit(PyClass& cl) const {
     cl.def("type_info", &boost_type_info, bp::arg("self"),

--- a/include/eigenpy/utils/scalar-name.hpp
+++ b/include/eigenpy/utils/scalar-name.hpp
@@ -30,7 +30,7 @@ struct scalar_name<long double> {
 };
 
 template <typename Scalar>
-struct scalar_name<std::complex<Scalar> > {
+struct scalar_name<std::complex<Scalar>> {
   static std::string shortname() { return "c" + scalar_name<Scalar>(); };
 };
 }  // namespace eigenpy

--- a/include/eigenpy/utils/traits.hpp
+++ b/include/eigenpy/utils/traits.hpp
@@ -31,11 +31,11 @@ struct is_python_complex : std::false_type {};
 
 /// From boost/python/converter/builtin_converters
 template <>
-struct is_python_complex<std::complex<float> > : std::true_type {};
+struct is_python_complex<std::complex<float>> : std::true_type {};
 template <>
-struct is_python_complex<std::complex<double> > : std::true_type {};
+struct is_python_complex<std::complex<double>> : std::true_type {};
 template <>
-struct is_python_complex<std::complex<long double> > : std::true_type {};
+struct is_python_complex<std::complex<long double>> : std::true_type {};
 
 template <typename T>
 struct is_python_primitive_type_helper

--- a/include/eigenpy/variant.hpp
+++ b/include/eigenpy/variant.hpp
@@ -42,7 +42,7 @@ struct is_empty_variant : std::false_type {};
 
 /// std::variant implementation
 template <typename ResultType, typename... Alternatives>
-struct VariantVisitorType<ResultType, std::variant<Alternatives...> > {
+struct VariantVisitorType<ResultType, std::variant<Alternatives...>> {
   typedef std::variant<Alternatives...> variant_type;
   typedef ResultType result_type;
 
@@ -58,12 +58,12 @@ struct VariantVisitorType<ResultType, std::variant<Alternatives...> > {
 };
 
 template <typename... Alternatives>
-struct VariantAlternatives<std::variant<Alternatives...> > {
+struct VariantAlternatives<std::variant<Alternatives...>> {
   typedef boost::mpl::vector<Alternatives...> types;
 };
 
 template <typename... Alternatives>
-struct empty_variant<std::variant<Alternatives...> > {
+struct empty_variant<std::variant<Alternatives...>> {
   typedef std::monostate type;
 };
 
@@ -74,7 +74,7 @@ struct is_empty_variant<std::monostate> : std::true_type {};
 
 /// boost::variant implementation
 template <typename ResultType, typename... Alternatives>
-struct VariantVisitorType<ResultType, boost::variant<Alternatives...> >
+struct VariantVisitorType<ResultType, boost::variant<Alternatives...>>
     : boost::static_visitor<ResultType> {
   typedef boost::variant<Alternatives...> variant_type;
   typedef ResultType result_type;
@@ -90,12 +90,12 @@ struct VariantVisitorType<ResultType, boost::variant<Alternatives...> >
 };
 
 template <typename... Alternatives>
-struct VariantAlternatives<boost::variant<Alternatives...> > {
+struct VariantAlternatives<boost::variant<Alternatives...>> {
   typedef typename boost::variant<Alternatives...>::types types;
 };
 
 template <typename... Alternatives>
-struct empty_variant<boost::variant<Alternatives...> > {
+struct empty_variant<boost::variant<Alternatives...>> {
   typedef boost::blank type;
 };
 

--- a/python/main.cpp
+++ b/python/main.cpp
@@ -78,7 +78,7 @@ BOOST_PYTHON_MODULE(eigenpy_pywrap) {
   }
 
   exposeIsApprox<double>();
-  exposeIsApprox<std::complex<double> >();
+  exposeIsApprox<std::complex<double>>();
 
   exposeDecompositions();
 }

--- a/src/decompositions/accelerate.cpp
+++ b/src/decompositions/accelerate.cpp
@@ -21,8 +21,8 @@ void exposeAccelerate() {
       .value("SparseOrderMetis", SparseOrderMetis)
       .value("SparseOrderCOLAMD", SparseOrderCOLAMD);
 
-#define EXPOSE_ACCELERATE_DECOMPOSITION(name, doc)            \
-  AccelerateImplVisitor<name<ColMajorSparseMatrix> >::expose( \
+#define EXPOSE_ACCELERATE_DECOMPOSITION(name, doc)           \
+  AccelerateImplVisitor<name<ColMajorSparseMatrix>>::expose( \
       EIGENPY_STRINGIZE(name), doc)
 
   EXPOSE_ACCELERATE_DECOMPOSITION(

--- a/src/matrix-complex-double.cpp
+++ b/src/matrix-complex-double.cpp
@@ -6,7 +6,7 @@
 
 namespace eigenpy {
 void exposeMatrixComplexDouble() {
-  exposeType<std::complex<double> >();
+  exposeType<std::complex<double>>();
   exposeType<std::complex<double>, Eigen::RowMajor>();
 }
 }  // namespace eigenpy

--- a/src/matrix-complex-float.cpp
+++ b/src/matrix-complex-float.cpp
@@ -6,7 +6,7 @@
 
 namespace eigenpy {
 void exposeMatrixComplexFloat() {
-  exposeType<std::complex<float> >();
+  exposeType<std::complex<float>>();
   exposeType<std::complex<float>, Eigen::RowMajor>();
 }
 }  // namespace eigenpy

--- a/src/matrix-complex-long-double.cpp
+++ b/src/matrix-complex-long-double.cpp
@@ -6,7 +6,7 @@
 
 namespace eigenpy {
 void exposeMatrixComplexLongDouble() {
-  exposeType<std::complex<long double> >();
+  exposeType<std::complex<long double>>();
   exposeType<std::complex<long double>, Eigen::RowMajor>();
 }
 }  // namespace eigenpy

--- a/src/solvers/solvers.cpp
+++ b/src/solvers/solvers.cpp
@@ -17,16 +17,15 @@ namespace eigenpy {
 void exposeSolvers() {
   using namespace Eigen;
   ConjugateGradientVisitor<
-      ConjugateGradient<MatrixXd, Lower | Upper> >::expose();
+      ConjugateGradient<MatrixXd, Lower | Upper>>::expose();
 #if EIGEN_VERSION_AT_LEAST(3, 3, 5)
   LeastSquaresConjugateGradientVisitor<LeastSquaresConjugateGradient<
-      MatrixXd,
-      LeastSquareDiagonalPreconditioner<MatrixXd::Scalar> > >::expose();
+      MatrixXd, LeastSquareDiagonalPreconditioner<MatrixXd::Scalar>>>::expose();
 #endif
 
   // Conjugate gradient with limited BFGS preconditioner
   ConjugateGradientVisitor<
-      ConjugateGradient<MatrixXd, Lower | Upper, IdentityPreconditioner> >::
+      ConjugateGradient<MatrixXd, Lower | Upper, IdentityPreconditioner>>::
       expose("IdentityConjugateGradient");
   //    ConjugateGradientVisitor<
   //    ConjugateGradient<MatrixXd,Lower|Upper,LimitedBFGSPreconditioner<double,Dynamic,Lower|Upper>

--- a/unittest/bind_virtual_factory.cpp
+++ b/unittest/bind_virtual_factory.cpp
@@ -74,7 +74,7 @@ struct VirtualClassWrapper : MyVirtualClass, bp::wrapper<MyVirtualClass> {
   shared_ptr<MyVirtualData> createData() const override {
     if (bp::override fo = this->get_override("createData")) {
       bp::object result = fo().as<bp::object>();
-      return bp::extract<shared_ptr<MyVirtualData> >(result);
+      return bp::extract<shared_ptr<MyVirtualData>>(result);
     }
     return default_createData();
   }
@@ -136,7 +136,7 @@ BOOST_PYTHON_MODULE(bind_virtual_factory) {
       .def("createData", &MyVirtualClass::createData,
            &VirtualClassWrapper::default_createData, bp::args("self"));
 
-  bp::register_ptr_to_python<shared_ptr<MyVirtualData> >();
+  bp::register_ptr_to_python<shared_ptr<MyVirtualData>>();
   /// Trampoline used as 1st argument
   /// otherwise if passed as "HeldType", we need to define
   /// the constructor and call initializer manually.

--- a/unittest/complex.cpp
+++ b/unittest/complex.cpp
@@ -56,7 +56,7 @@ template <typename Scalar, int Rows, int Cols, int Options>
 Eigen::Matrix<std::complex<Scalar>, Rows, Cols, Options> ascomplex(
     const Eigen::Matrix<Scalar, Rows, Cols, Options> &mat) {
   typedef Eigen::Matrix<std::complex<Scalar>, Rows, Cols, Options> ReturnType;
-  return ReturnType(mat.template cast<std::complex<Scalar> >());
+  return ReturnType(mat.template cast<std::complex<Scalar>>());
 }
 
 BOOST_PYTHON_MODULE(complex) {

--- a/unittest/matrix.cpp
+++ b/unittest/matrix.cpp
@@ -196,38 +196,38 @@ BOOST_PYTHON_MODULE(matrix) {
   bp::def("asRowMajorFromRowMajorVector",
           copy<Eigen::RowVectorXd, Eigen::RowVectorXd>);
 
-  bp::def("copyBoolToBool", copy_same<Eigen::Matrix<bool, -1, -1> >);
+  bp::def("copyBoolToBool", copy_same<Eigen::Matrix<bool, -1, -1>>);
 
-  bp::def("copyInt8ToInt8", copy_same<Eigen::Matrix<int8_t, -1, -1> >);
-  bp::def("copyCharToChar", copy_same<Eigen::Matrix<char, -1, -1> >);
-  bp::def("copyUCharToUChar", copy_same<Eigen::Matrix<unsigned char, -1, -1> >);
+  bp::def("copyInt8ToInt8", copy_same<Eigen::Matrix<int8_t, -1, -1>>);
+  bp::def("copyCharToChar", copy_same<Eigen::Matrix<char, -1, -1>>);
+  bp::def("copyUCharToUChar", copy_same<Eigen::Matrix<unsigned char, -1, -1>>);
 
-  bp::def("copyInt16ToInt16", copy_same<Eigen::Matrix<int16_t, -1, -1> >);
-  bp::def("copyUInt16ToUInt16", copy_same<Eigen::Matrix<uint16_t, -1, -1> >);
+  bp::def("copyInt16ToInt16", copy_same<Eigen::Matrix<int16_t, -1, -1>>);
+  bp::def("copyUInt16ToUInt16", copy_same<Eigen::Matrix<uint16_t, -1, -1>>);
 
-  bp::def("copyInt32ToInt32", copy_same<Eigen::Matrix<int32_t, -1, -1> >);
-  bp::def("copyUInt32ToUInt32", copy_same<Eigen::Matrix<uint32_t, -1, -1> >);
+  bp::def("copyInt32ToInt32", copy_same<Eigen::Matrix<int32_t, -1, -1>>);
+  bp::def("copyUInt32ToUInt32", copy_same<Eigen::Matrix<uint32_t, -1, -1>>);
 
-  bp::def("copyInt64ToInt64", copy_same<Eigen::Matrix<int64_t, -1, -1> >);
-  bp::def("copyUInt64ToUInt64", copy_same<Eigen::Matrix<uint64_t, -1, -1> >);
+  bp::def("copyInt64ToInt64", copy_same<Eigen::Matrix<int64_t, -1, -1>>);
+  bp::def("copyUInt64ToUInt64", copy_same<Eigen::Matrix<uint64_t, -1, -1>>);
 
-  bp::def("copyLongToLong", copy_same<Eigen::Matrix<long, -1, -1> >);
-  bp::def("copyULongToULong", copy_same<Eigen::Matrix<unsigned long, -1, -1> >);
+  bp::def("copyLongToLong", copy_same<Eigen::Matrix<long, -1, -1>>);
+  bp::def("copyULongToULong", copy_same<Eigen::Matrix<unsigned long, -1, -1>>);
 
   bp::def("copyLongLongToLongLong",
-          copy_same<Eigen::Matrix<long long, -1, -1> >);
+          copy_same<Eigen::Matrix<long long, -1, -1>>);
   bp::def("copyULongLongToULongLong",
-          copy_same<Eigen::Matrix<unsigned long long, -1, -1> >);
+          copy_same<Eigen::Matrix<unsigned long long, -1, -1>>);
 
-  bp::def("copyFloatToFloat", copy_same<Eigen::Matrix<float, -1, -1> >);
-  bp::def("copyDoubleToDouble", copy_same<Eigen::Matrix<double, -1, -1> >);
+  bp::def("copyFloatToFloat", copy_same<Eigen::Matrix<float, -1, -1>>);
+  bp::def("copyDoubleToDouble", copy_same<Eigen::Matrix<double, -1, -1>>);
   bp::def("copyLongDoubleToLongDouble",
-          copy_same<Eigen::Matrix<long double, -1, -1> >);
+          copy_same<Eigen::Matrix<long double, -1, -1>>);
 
   bp::def("copyCFloatToCFloat",
-          copy_same<Eigen::Matrix<std::complex<float>, -1, -1> >);
+          copy_same<Eigen::Matrix<std::complex<float>, -1, -1>>);
   bp::def("copyCDoubleToCDouble",
-          copy_same<Eigen::Matrix<std::complex<double>, -1, -1> >);
+          copy_same<Eigen::Matrix<std::complex<double>, -1, -1>>);
   bp::def("copyCLongDoubleToCLongDouble",
-          copy_same<Eigen::Matrix<std::complex<long double>, -1, -1> >);
+          copy_same<Eigen::Matrix<std::complex<long double>, -1, -1>>);
 }

--- a/unittest/return_by_ref.cpp
+++ b/unittest/return_by_ref.cpp
@@ -26,8 +26,7 @@ void expose_matrix_class(const std::string& name) {
   using namespace Eigen;
   namespace bp = boost::python;
 
-  bp::class_<Base<MatrixType> >(name.c_str(),
-                                bp::init<DenseIndex, DenseIndex>())
+  bp::class_<Base<MatrixType>>(name.c_str(), bp::init<DenseIndex, DenseIndex>())
       .def("show", &Base<MatrixType>::show)
       .def("ref", &Base<MatrixType>::ref, bp::return_internal_reference<>())
       .def("const_ref", &Base<MatrixType>::const_ref,

--- a/unittest/sparse_matrix.cpp
+++ b/unittest/sparse_matrix.cpp
@@ -26,7 +26,7 @@ Eigen::SparseMatrix<Scalar, Options> matrix1x1(const Scalar& value) {
 
 template <typename Scalar, int Options>
 Eigen::SparseMatrix<Scalar, Options> diagonal(
-    const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1> >&
+    const Eigen::Ref<const Eigen::Matrix<Scalar, Eigen::Dynamic, 1>>&
         diag_values) {
   typedef Eigen::SparseMatrix<Scalar, Options> ReturnType;
   ReturnType mat(diag_values.size(), diag_values.size());

--- a/unittest/std_map.cpp
+++ b/unittest/std_map.cpp
@@ -39,10 +39,10 @@ BOOST_PYTHON_MODULE(std_map) {
 
   eigenpy::StdMapPythonVisitor<
       std::string, double, std::less<std::string>,
-      std::allocator<std::pair<const std::string, double> >,
+      std::allocator<std::pair<const std::string, double>>,
       true>::expose("StdMap_Double");
 
-  eigenpy::GenericMapVisitor<boost::unordered_map<std::string, int> >::expose(
+  eigenpy::GenericMapVisitor<boost::unordered_map<std::string, int>>::expose(
       "boost_map_int");
 
   using StdMap_X = std::map<std::string, X>;

--- a/unittest/std_unique_ptr.cpp
+++ b/unittest/std_unique_ptr.cpp
@@ -27,8 +27,8 @@ std::unique_ptr<std::string> make_unique_str() {
   return std::make_unique<std::string>("str");
 }
 
-std::unique_ptr<std::complex<double> > make_unique_complex() {
-  return std::make_unique<std::complex<double> >(1., 0.);
+std::unique_ptr<std::complex<double>> make_unique_complex() {
+  return std::make_unique<std::complex<double>>(1., 0.);
 }
 
 struct UniquePtrHolder {
@@ -36,13 +36,13 @@ struct UniquePtrHolder {
       : int_ptr(std::make_unique<int>(20)),
         v1_ptr(std::make_unique<V1>(200)),
         str_ptr(std::make_unique<std::string>("str")),
-        complex_ptr(std::make_unique<std::complex<double> >(1., 0.)) {}
+        complex_ptr(std::make_unique<std::complex<double>>(1., 0.)) {}
 
   std::unique_ptr<int> int_ptr;
   std::unique_ptr<V1> v1_ptr;
   std::unique_ptr<V1> null_ptr;
   std::unique_ptr<std::string> str_ptr;
-  std::unique_ptr<std::complex<double> > complex_ptr;
+  std::unique_ptr<std::complex<double>> complex_ptr;
 };
 
 BOOST_PYTHON_MODULE(std_unique_ptr) {

--- a/unittest/std_vector.cpp
+++ b/unittest/std_vector.cpp
@@ -9,7 +9,7 @@
 
 template <typename MatType>
 void printVectorOfMatrix(
-    const std::vector<MatType, Eigen::aligned_allocator<MatType> > &Ms) {
+    const std::vector<MatType, Eigen::aligned_allocator<MatType>> &Ms) {
   const std::size_t n = Ms.size();
   for (std::size_t i = 0; i < n; i++) {
     std::cout << "el[" << i << "] =\n" << Ms[i] << '\n';
@@ -17,14 +17,14 @@ void printVectorOfMatrix(
 }
 
 template <typename MatType>
-std::vector<MatType, Eigen::aligned_allocator<MatType> > copy(
-    const std::vector<MatType, Eigen::aligned_allocator<MatType> > &Ms) {
-  std::vector<MatType, Eigen::aligned_allocator<MatType> > out = Ms;
+std::vector<MatType, Eigen::aligned_allocator<MatType>> copy(
+    const std::vector<MatType, Eigen::aligned_allocator<MatType>> &Ms) {
+  std::vector<MatType, Eigen::aligned_allocator<MatType>> out = Ms;
   return out;
 }
 
 template <typename MatType>
-void setZero(std::vector<MatType, Eigen::aligned_allocator<MatType> > &Ms) {
+void setZero(std::vector<MatType, Eigen::aligned_allocator<MatType>> &Ms) {
   for (std::size_t i = 0; i < Ms.size(); i++) {
     Ms[i].setZero();
   }
@@ -58,14 +58,14 @@ BOOST_PYTHON_MODULE(std_vector) {
   // Mat2d don't have tolist, reserve, mutable __getitem__ and from list
   // conversion
   // exposeStdVectorEigenSpecificType must add those methods to StdVec_Mat2d
-  bp::class_<std::vector<Eigen::Matrix2d> >("StdVec_Mat2d")
-      .def(boost::python::vector_indexing_suite<
-           std::vector<Eigen::Matrix2d> >());
+  bp::class_<std::vector<Eigen::Matrix2d>>("StdVec_Mat2d")
+      .def(
+          boost::python::vector_indexing_suite<std::vector<Eigen::Matrix2d>>());
   exposeStdVectorEigenSpecificType<Eigen::Matrix2d>("Mat2d");
 
   // Test API regression:
   // Exposing a `std::vector` with documentation doesn't clash with
   // exposing a `std::vector` with a visitor
-  StdVectorPythonVisitor<std::vector<CustomTestStruct> >::expose(
+  StdVectorPythonVisitor<std::vector<CustomTestStruct>>::expose(
       "StdVec_CustomTestStruct", "some documentation");
 }

--- a/unittest/user_type.cpp
+++ b/unittest/user_type.cpp
@@ -16,7 +16,7 @@ namespace Eigen {
 /// @brief Eigen::NumTraits<> specialization for casadi::SX
 ///
 template <typename Scalar>
-struct NumTraits<CustomType<Scalar> > {
+struct NumTraits<CustomType<Scalar>> {
   typedef CustomType<Scalar> Real;
   typedef CustomType<Scalar> NonInteger;
   typedef CustomType<Scalar> Literal;


### PR DESCRIPTION
- **pre-commit config : actually delegate to .clang-format config file**
- **.clang-format : increase Standard to Cpp11**
- **pre-commit: run all**
- **.git-blame-ignore-revs : update**
- **Update CHANGELOG**

This PR would require setting the minimum required version of the C++ standard to 11 I think, because stuff like `vector<A<T>>` without a space between the last two angle brackets for templates doesn't work on some C++03 compilers if I recall correctly.