### PR TITLE
Use devel as default branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Change the default branch to `devel` ([#547](https://github.com/stack-of-tasks/eigenpy/pull/547))
+
 ## [3.11.0] - 2025-04-25
 
 ### Added
 
-- Add user-defined literal ""_a for bp::arg ([#545)(https://github.com/stack-of-tasks/eigenpy/pull/545))
+- Add user-defined literal ""_a for bp::arg ([#545](https://github.com/stack-of-tasks/eigenpy/pull/545))
 
 ### Fixed
 

--- a/development/release.md
+++ b/development/release.md
@@ -6,7 +6,6 @@ To create a release with Pixi run the following commands on the **devel** branch
 EIGENPY_VERSION=X.Y.Z pixi run release_new_version
 git push origin
 git push origin vX.Y.Z
-git push origin devel:master
 ```
 
 Where `X.Y.Z` is the new version.


### PR DESCRIPTION
In our past practices, we had two main branches:
- `devel`: work in progress
- `master`: stable release (default)

By default, user will clone `master`, the stable and tested version.

This workflow is no more mandatory:
- Our CI has improved, `devel` is more stable than before
- Most user doesn't compile from sources and use packages instead (pip, conda, nix, apt, ...)

Given these changes and the fact that several tools assume the default branch to be the work in progress one, we have decided to change the default branch to `devel`.

This means that when you clone our repository, you will now be working with the ongoing development version by default.