### PR TITLE
ci: bump ROS

### DIFF
--- a/.github/workflows/ros_ci.yml
+++ b/.github/workflows/ros_ci.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           submodules: recursive
       # Run industrial_ci
-      - uses: 'ros-industrial/industrial_ci@3e67ec54d63496e076267392148a26229740befc'
+      - uses: 'ros-industrial/industrial_ci@e3d16c224caf4832cf68e74093eb70f3a979b4cc'
         env: ${{ matrix.env }}
 
   check:


### PR DESCRIPTION
because it is broken, and dependabot doesn't feel like fixing it