### PR TITLE
dockgen: init

### DIFF
--- a/.github/workflows/dockgen.yml
+++ b/.github/workflows/dockgen.yml
@@ -1,0 +1,53 @@
+name: "Publish docker image"
+
+on:
+  push:
+    branches:
+      - devel
+    tags:
+      - "v*"
+
+jobs:
+  dockgen:
+    runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v6
+      - run: uvx dockgen
+
+      # https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
   rev: v0.24.2
   hooks:
   - id: toml-sort-fix
-    exclude: pixi.toml
+    exclude: pixi.toml|dockgen.toml
 - repo: https://github.com/pre-commit/mirrors-clang-format
   rev: v20.1.7
   hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Docker images `ghcr.io/stack-of-tasks/eigenpy` ([#575](https://github.com/stack-of-tasks/eigenpy/pull/575))
+
 ### Changed
 
 - Change the default branch to `devel` ([#547](https://github.com/stack-of-tasks/eigenpy/pull/547))

--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ and then install **EigenPy** for Python 3.x with:
 brew install eigenpy
 ```
 
+### Docker
+
+```
+docker run --rm -it ghcr.io/stack-of-tasks/eigenpy:devel
+```
+
 ## Build
 
 Build instruction can be found [here](./development/build.md)

--- a/dockgen.toml
+++ b/dockgen.toml
@@ -1,0 +1,7 @@
+[jrl-cmakemodules]
+url = "github:jrl-umi3218"
+
+[eigenpy]
+url = "."
+apt_deps = ["libboost-all-dev", "libeigen3-dev", "python3-numpy", "python3-scipy"]
+src_deps = ["jrl-cmakemodules"]


### PR DESCRIPTION
This setup an automated docker image build system, which can be used as:
- `docker run ghcr.io/stack-of-tasks/eigenpy:devel` for fresh images
- `docker run ghcr.io/stack-of-tasks/eigenpy{:v3.12.0,:latest,}` for releases

It is a first step for https://github.com/stack-of-tasks/pinocchio/issues/2580