### PR TITLE
Use VS2022 in CI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
-# GitHub syntax highlighting
-pixi.lock linguist-language=YAML
+# SCM syntax highlighting & preventing 3-way merges
+pixi.lock merge=binary linguist-language=YAML linguist-generated=true -diff
 

--- a/.github/workflows/macos-linux-windows-pixi.yml
+++ b/.github/workflows/macos-linux-windows-pixi.yml
@@ -53,11 +53,11 @@ jobs:
             cxx_options: '-mavx2'
 
         include:
-          - os: windows-latest
+          - os: windows-2022
             environment: all
             cxx_options: ''
             build_type: Release
-          - os: windows-latest
+          - os: windows-2022
             environment: all-clang-cl
             cxx_options: ''
             build_type: Release
@@ -101,7 +101,7 @@ jobs:
   #   strategy:
   #     fail-fast: false
   #     matrix:
-  #       os: [ubuntu-latest, macos-latest, macos-15-intel, windows-latest]
+  #       os: [ubuntu-latest, macos-latest, macos-15-intel, windows-2022]
 
   #   steps:
   #   - uses: actions/checkout@v6


### PR DESCRIPTION
- Github migrate windows-latest to windows image using vs2026. Right now, it's not the default compiler used by conda and workflow will fail.
- Update pixi.lock gitattributes.